### PR TITLE
Gracefully handle JSON fetch failures and pistol initialization

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -53,7 +53,10 @@ const models = {};
 let zombiesSpawned = false;
 
 fetch('objects.json')
-  .then(res => res.json())
+  .then(res => {
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+  })
   .then(async objects => {
     // Load geometries/materials/models
     for (const obj of objects) {
@@ -90,7 +93,6 @@ fetch('objects.json')
         spawnZombiesFromMap(scene, mapObjects, models, materials);
         zombiesSpawned = true;
       }
-      addPistolToCamera(camera);
     });
   })
   .catch(err => {
@@ -105,6 +107,7 @@ updateHUD(10, 100);
 initCrosshair();
 enablePointerLock(renderer, cameraContainer, camera);
 setupZoom(camera);
+addPistolToCamera(camera);
 
 document.addEventListener('mousedown', (e) => {
   if (e.button === 0) shootPistol(scene, camera);

--- a/js/mapLoader.js
+++ b/js/mapLoader.js
@@ -34,7 +34,17 @@ function loadGLTFModel(id, modelPath) {
 
 export async function loadMap(scene) {
     const rulesResponse = await fetch('mapmaker.php?list_json_files=1');
-    const jsonFiles = await rulesResponse.json();
+    if (!rulesResponse.ok) {
+        console.error('Failed to fetch object rule list.');
+        return [];
+    }
+    let jsonFiles;
+    try {
+        jsonFiles = await rulesResponse.json();
+    } catch (e) {
+        console.error('Invalid JSON from mapmaker.php', e);
+        return [];
+    }
     objectRules = {};
     geometries = {};
     materials = {};
@@ -48,8 +58,12 @@ export async function loadMap(scene) {
         if (file === 'saved_map') continue;
         const res = await fetch(`${file}.json`);
         if (!res.ok) continue;
-        const arr = await res.json();
-        allDefinitions = allDefinitions.concat(arr);
+        try {
+            const arr = await res.json();
+            allDefinitions = allDefinitions.concat(arr);
+        } catch (e) {
+            console.warn(`Invalid JSON in ${file}.json`, e);
+        }
     }
 
     for (const obj of allDefinitions) {
@@ -91,7 +105,17 @@ export async function loadMap(scene) {
     await Promise.all(gltfPromises);
 
     const resMap = await fetch('load_map.php');
-    const mapData = await resMap.json();
+    if (!resMap.ok) {
+        console.error('Failed to fetch map data.');
+        return [];
+    }
+    let mapData;
+    try {
+        mapData = await resMap.json();
+    } catch (e) {
+        console.error('Invalid JSON from load_map.php', e);
+        return [];
+    }
 
     loadedObjects = [];
 

--- a/js/pistol.js
+++ b/js/pistol.js
@@ -24,6 +24,11 @@ export function addPistolToCamera(camera) {
 }
 
 export function shootPistol(scene, camera) {
+    if (!pistol) {
+        console.warn('Pistol not ready.');
+        return;
+    }
+
     if (isReloading) {
         console.log("? Reload canceled + firing...");
         isReloading = false;
@@ -99,6 +104,12 @@ export function shootPistol(scene, camera) {
 }
 
 export function reloadAmmo(onReloaded) {
+    if (!pistol) {
+        console.warn('Pistol not ready.');
+        onReloaded?.();
+        return;
+    }
+
     if (isReloading || clipAmmo === maxClip) {
         console.log("? Already full or reloading.");
         onReloaded?.();


### PR DESCRIPTION
## Summary
- Prevent pistol actions when gun has not been initialized
- Ensure game still initializes pistol even if object JSON fails
- Guard map loading against invalid or missing JSON responses

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c36a804b34833397d60de52bad8a81