### PR TITLE
Add player collision effects with zombies

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,19 @@
             border-radius: 50%;
             pointer-events: none;
         }
+
+        .splash {
+            position: absolute;
+            width: 50px; height: 50px;
+            background: rgba(255, 0, 0, 0.5);
+            border-radius: 50%;
+            pointer-events: none;
+            animation: fadeout 0.5s forwards;
+        }
+
+        @keyframes fadeout {
+            to { opacity: 0; transform: scale(2); }
+        }
     </style>
 </head>
 <body>

--- a/js/main.js
+++ b/js/main.js
@@ -16,6 +16,40 @@ scene.add(cameraContainer);
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(window.innerWidth, window.innerHeight);
 document.body.appendChild(renderer.domElement);
+const canvas = renderer.domElement;
+
+function spawnSplash() {
+  const splash = document.createElement('div');
+  splash.className = 'splash';
+  splash.style.left = `${Math.random() * 80 + 10}%`;
+  splash.style.top = `${Math.random() * 80 + 10}%`;
+  document.body.appendChild(splash);
+  setTimeout(() => splash.remove(), 500);
+}
+
+let shakeTime = 0;
+function triggerShake() {
+  shakeTime = 0.3;
+}
+
+function applyShake(delta) {
+  if (shakeTime > 0) {
+    const intensity = 5;
+    const dx = (Math.random() * 2 - 1) * intensity;
+    const dy = (Math.random() * 2 - 1) * intensity;
+    canvas.style.transform = `translate(${dx}px, ${dy}px)`;
+    shakeTime -= delta;
+  } else {
+    canvas.style.transform = '';
+  }
+}
+
+function handlePlayerHit() {
+  movement.setEnabled(false);
+  setTimeout(() => movement.setEnabled(true), 500);
+  spawnSplash();
+  triggerShake();
+}
 
 // ---- Torch (SpotLight) setup ----
 const TORCH_COLOR = 0xffe5a0;
@@ -140,6 +174,7 @@ function animate() {
   const delta = clock.getDelta();
 
   movement.update();
+  applyShake(delta);
 
   // Chunk logic (this does not affect zombies)
   const playerX = Math.round(cameraContainer.position.x / UPDATE_CHUNK_SIZE) * UPDATE_CHUNK_SIZE;
@@ -154,7 +189,7 @@ function animate() {
 
   // ---- ZOMBIE AI update ----
   const playerPos = cameraContainer.position;
-  updateZombies(playerPos, delta, getLoadedObjects());
+  updateZombies(playerPos, delta, getLoadedObjects(), handlePlayerHit);
 
   checkPickups(cameraContainer, scene);
   updateBullets(delta);

--- a/js/movement.js
+++ b/js/movement.js
@@ -3,6 +3,7 @@ import { reloadAmmo } from './pistol.js';
 
 export function setupMovement(cameraContainer, camera) {
     const keys = {};
+    let enabled = true;
     document.addEventListener('keydown', (e) => {
         keys[e.code] = true;
 
@@ -32,6 +33,7 @@ export function setupMovement(cameraContainer, camera) {
     }
 
     function update() {
+        if (!enabled) return;
         const dir = new THREE.Vector3();
         camera.getWorldDirection(dir);
         dir.y = 0;
@@ -54,5 +56,9 @@ export function setupMovement(cameraContainer, camera) {
         }
     }
 
-    return { update };
+    function setEnabled(val) {
+        enabled = val;
+    }
+
+    return { update, setEnabled };
 }

--- a/js/zombie.js
+++ b/js/zombie.js
@@ -47,7 +47,7 @@ export function getZombies() {
 
 // Basic AI: Only "active" if within spotDistance of player!
 // Make sure to pass [...getLoadedObjects(), ...getZombies()] as collidableObjects!
-export function updateZombies(playerPosition, delta, collidableObjects = []) {
+export function updateZombies(playerPosition, delta, collidableObjects = [], onPlayerCollide = () => {}) {
     zombies.forEach(zombie => {
         if (zombie.userData.hp <= 0) return; // dead
 
@@ -55,6 +55,10 @@ export function updateZombies(playerPosition, delta, collidableObjects = []) {
         const dist = distance3D(zombie.position, playerPosition);
 
         if (dist > spotDistance) return; // out of aggro range
+
+        if (dist < 0.5) {
+            onPlayerCollide();
+        }
 
         // --- Simple AI: move toward player with collision ---
         const toPlayer = new THREE.Vector3().copy(playerPosition).sub(zombie.position);


### PR DESCRIPTION
## Summary
- Disable player movement briefly and show a blood splash when a zombie collides with the player
- Add simple camera shake effect tied to zombie hits
- Expose movement enabling control and allow zombies to notify on player collision

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c37215120c8333aca45e95c6544d78