### PR TITLE
Repel player on zombie collision

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -57,6 +57,24 @@ export function updateZombies(playerPosition, delta, collidableObjects = [], onP
         if (dist > spotDistance) return; // out of aggro range
 
         if (dist < 0.5) {
+            const pushDir = new THREE.Vector3().copy(playerPosition).sub(zombie.position);
+            pushDir.y = 0;
+            if (pushDir.lengthSq() > 0) {
+                pushDir.setLength(0.5);
+                const nextPlayerPos = playerPosition.clone().add(pushDir);
+                let collision = false;
+                for (const obj of collidableObjects) {
+                    if (!obj.userData || !obj.userData.rules || !obj.userData.rules.collidable) continue;
+                    if (obj === zombie) continue;
+                    if (nextPlayerPos.distanceTo(obj.position) < 0.5) {
+                        collision = true;
+                        break;
+                    }
+                }
+                if (!collision) {
+                    playerPosition.copy(nextPlayerPos);
+                }
+            }
             onPlayerCollide();
         }
 


### PR DESCRIPTION
## Summary
- Push the player away from zombies upon collision, checking for obstacles before applying the displacement.

## Testing
- `node --check js/zombie.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c37448eb148333990387d53994cc42