### PR TITLE
Improve zombie pathfinding through tight corridors

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -9,6 +9,61 @@ function distance3D(a, b) {
     return Math.sqrt(dx * dx + dy * dy + dz * dz);
 }
 
+// Build a simple grid of blocked cells from collidable objects
+function buildObstacleMap(objects) {
+    const map = new Set();
+    for (const obj of objects) {
+        const rules = obj.userData && obj.userData.rules;
+        if (!rules || !rules.collidable) continue;
+        const box = new THREE.Box3().setFromObject(obj);
+        const minX = Math.floor(box.min.x);
+        const maxX = Math.floor(box.max.x);
+        const minZ = Math.floor(box.min.z);
+        const maxZ = Math.floor(box.max.z);
+        for (let x = minX; x <= maxX; x++) {
+            for (let z = minZ; z <= maxZ; z++) {
+                map.add(`${x},${z}`);
+            }
+        }
+    }
+    return map;
+}
+
+// Breadth-first search on grid to reach goal
+function findPath(start, goal, obstacles, maxNodes = 4000) {
+    const startKey = `${start.x},${start.z}`;
+    const queue = [start];
+    const cameFrom = { [startKey]: null };
+    const dirs = [
+        [1, 0], [-1, 0], [0, 1], [0, -1]
+    ];
+    while (queue.length && Object.keys(cameFrom).length < maxNodes) {
+        const current = queue.shift();
+        const curKey = `${current.x},${current.z}`;
+        if (current.x === goal.x && current.z === goal.z) {
+            const path = [];
+            let k = curKey;
+            while (k) {
+                const [cx, cz] = k.split(',').map(Number);
+                path.push({ x: cx + 0.5, z: cz + 0.5 });
+                k = cameFrom[k];
+            }
+            path.reverse();
+            path.shift(); // remove start
+            return path;
+        }
+        for (const [dx, dz] of dirs) {
+            const nx = current.x + dx, nz = current.z + dz;
+            const nk = `${nx},${nz}`;
+            if (cameFrom[nk] !== undefined) continue;
+            if (obstacles.has(nk) && nk !== startKey) continue;
+            cameFrom[nk] = curKey;
+            queue.push({ x: nx, z: nz });
+        }
+    }
+    return [];
+}
+
 // Loads zombie type ids from zombies.json (async, cached)
 async function getZombieTypeIds() {
     if (zombieTypeIds) return zombieTypeIds;
@@ -48,42 +103,63 @@ export function getZombies() {
 // Basic AI: Only "active" if within spotDistance of player!
 // Make sure to pass [...getLoadedObjects(), ...getZombies()] as collidableObjects!
 export function updateZombies(playerPosition, delta, collidableObjects = [], onPlayerCollide = () => {}) {
+    const obstacleMap = buildObstacleMap(collidableObjects);
     zombies.forEach(zombie => {
         if (zombie.userData.hp <= 0) return; // dead
+
+        const stepBase = zombie.userData.speed * delta * 60;
+        const attemptMove = move => {
+            const nextPos = zombie.position.clone().add(move);
+            const zombieBox = new THREE.Box3().setFromObject(zombie);
+            zombieBox.translate(move);
+            for (const obj of collidableObjects) {
+                if (!obj.userData || !obj.userData.rules || !obj.userData.rules.collidable) continue;
+                if (obj === zombie) continue; // Don't collide with self
+                const objBox = new THREE.Box3().setFromObject(obj);
+                if (zombieBox.intersectsBox(objBox)) {
+                    return false;
+                }
+            }
+            zombie.position.copy(nextPos);
+            return true;
+        };
 
         const spotDistance = zombie.userData.spotDistance || 8;
         const dist = distance3D(zombie.position, playerPosition);
 
         // --- Wander when player is far away ---
         if (dist > spotDistance) {
+            zombie.userData.path = [];
             if (!zombie.userData.wanderDir || zombie.userData.wanderTimeout < performance.now()) {
                 const angle = Math.random() * Math.PI * 2;
                 zombie.userData.wanderDir = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle));
                 zombie.userData.wanderTimeout = performance.now() + 2000 + Math.random() * 3000;
             }
 
-            const step = zombie.userData.speed * delta * 60 * 0.5;
+            const step = stepBase * 0.5;
             const move = zombie.userData.wanderDir.clone().setLength(step);
-            const nextPos = zombie.position.clone().add(move);
-            const zombieBox = new THREE.Box3().setFromObject(zombie);
-            zombieBox.translate(move);
-            let collision = false;
-            for (const obj of collidableObjects) {
-                if (!obj.userData || !obj.userData.rules || !obj.userData.rules.collidable) continue;
-                if (obj === zombie) continue;
-                const objBox = new THREE.Box3().setFromObject(obj);
-                if (zombieBox.intersectsBox(objBox)) {
-                    collision = true;
-                    break;
-                }
-            }
-            if (!collision) {
-                zombie.position.copy(nextPos);
-            } else {
+            if (!attemptMove(move)) {
                 zombie.userData.wanderTimeout = 0; // pick new dir next frame
             }
             zombie.lookAt(zombie.position.x + zombie.userData.wanderDir.x, zombie.position.y, zombie.position.z + zombie.userData.wanderDir.z);
             return; // done with idle behaviour
+        }
+
+        // --- Follow path if one exists ---
+        if (zombie.userData.path && zombie.userData.path.length > 0) {
+            const target = zombie.userData.path[0];
+            const dir = new THREE.Vector3(target.x - zombie.position.x, 0, target.z - zombie.position.z);
+            if (dir.length() < 0.2) {
+                zombie.userData.path.shift();
+            } else {
+                dir.setLength(stepBase);
+                if (attemptMove(dir)) {
+                    zombie.lookAt(zombie.position.x + dir.x, zombie.position.y, zombie.position.z + dir.z);
+                    return;
+                } else {
+                    zombie.userData.path = [];
+                }
+            }
         }
 
         if (dist < 0.5) {
@@ -124,37 +200,26 @@ export function updateZombies(playerPosition, delta, collidableObjects = [], onP
             onPlayerCollide();
         }
 
-        // --- Simple AI: move toward player with simple avoidance ---
+        // --- Move toward player using simple pathfinding ---
         const toPlayer = new THREE.Vector3().copy(playerPosition).sub(zombie.position);
         if (toPlayer.length() > 0.1) {
-            const step = zombie.userData.speed * delta * 60;
-            toPlayer.setLength(step);
-
-            const attemptMove = move => {
-                const nextPos = zombie.position.clone().add(move);
-                const zombieBox = new THREE.Box3().setFromObject(zombie);
-                zombieBox.translate(move);
-                for (const obj of collidableObjects) {
-                    if (!obj.userData || !obj.userData.rules || !obj.userData.rules.collidable) continue;
-                    if (obj === zombie) continue; // Don't collide with self
-                    const objBox = new THREE.Box3().setFromObject(obj);
-                    if (zombieBox.intersectsBox(objBox)) {
-                        return false;
+            const moveDir = toPlayer.clone().setLength(stepBase);
+            if (!attemptMove(moveDir)) {
+                const start = { x: Math.floor(zombie.position.x), z: Math.floor(zombie.position.z) };
+                const goal = { x: Math.floor(playerPosition.x), z: Math.floor(playerPosition.z) };
+                const path = findPath(start, goal, obstacleMap);
+                if (path.length > 0) {
+                    zombie.userData.path = path;
+                } else {
+                    const left = new THREE.Vector3(-moveDir.z, 0, moveDir.x).setLength(stepBase);
+                    if (!attemptMove(left)) {
+                        const right = left.clone().negate();
+                        attemptMove(right);
                     }
                 }
-                zombie.position.copy(nextPos);
-                return true;
-            };
-
-            if (!attemptMove(toPlayer)) {
-                const left = new THREE.Vector3(-toPlayer.z, 0, toPlayer.x).setLength(step);
-                if (!attemptMove(left)) {
-                    const right = left.clone().negate();
-                    attemptMove(right);
-                }
+            } else {
+                zombie.lookAt(playerPosition.x, zombie.position.y, playerPosition.z);
             }
-
-            zombie.lookAt(playerPosition.x, zombie.position.y, playerPosition.z);
         }
     });
 }


### PR DESCRIPTION
## Summary
- add grid-based breadth-first search pathfinding utilities
- enable zombies to follow computed paths and navigate tight corridors

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c37d3c36988333a70020ef47900794