### PR TITLE
Increase zombie bounce on collision

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -151,7 +151,7 @@ export function updateZombies(playerPosition, delta, collidableObjects = [], onP
                 }
             }
 
-            zombie.position.add(move.clone().multiplyScalar(-0.5));
+            zombie.position.add(move.clone().multiplyScalar(-1));
             return false;
         };
 


### PR DESCRIPTION
## Summary
- Increase bounce distance when zombies collide with obstacles by reversing the full attempted move instead of half

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c38344c1a88333897dd335a08327cc