### PR TITLE
Scale zombie models to configured size

### DIFF
--- a/js/mapLoader.js
+++ b/js/mapLoader.js
@@ -129,6 +129,18 @@ export async function loadMap(scene) {
                     node.material.transparent = false;
                 }
             });
+            if (rule.geometry) {
+                const box = new THREE.Box3().setFromObject(mesh);
+                const size = new THREE.Vector3();
+                box.getSize(size);
+                if (size.x > 0 && size.y > 0 && size.z > 0) {
+                    mesh.scale.set(
+                        rule.geometry[0] / size.x,
+                        rule.geometry[1] / size.y,
+                        rule.geometry[2] / size.z
+                    );
+                }
+            }
             mesh.position.fromArray(position);
             mesh.rotation.y = rotation;
             mesh.userData = { ...item, rules: rule };


### PR DESCRIPTION
## Summary
- Scale GLTF models to match their defined geometry so zombies are smaller

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3874aab608333861e1550d880e808