### PR TITLE
Enable animated zombies

### DIFF
--- a/js/mapLoader.js
+++ b/js/mapLoader.js
@@ -7,6 +7,7 @@ let geometries = {};
 let materials = {};
 let textures = {};
 let gltfModels = {};
+let gltfAnimations = {};
 let gltfLoadedFlags = {};
 
 const textureLoader = new THREE.TextureLoader();
@@ -19,6 +20,7 @@ function loadGLTFModel(id, modelPath) {
             modelPath,
             gltf => {
                 gltfModels[id] = gltf.scene;
+                gltfAnimations[id] = gltf.animations || [];
                 gltfLoadedFlags[id] = true;
                 resolve();
             },
@@ -43,6 +45,7 @@ export async function loadMap(scene) {
     materials = {};
     textures = {};
     gltfModels = {};
+    gltfAnimations = {};
     gltfLoadedFlags = {};
 
     let allDefinitions = [];
@@ -140,6 +143,14 @@ export async function loadMap(scene) {
                         rule.geometry[2] / size.z
                     );
                 }
+            }
+            if (gltfAnimations[type] && gltfAnimations[type].length > 0) {
+                const mixer = new THREE.AnimationMixer(mesh);
+                gltfAnimations[type].forEach(clip => {
+                    const action = mixer.clipAction(clip);
+                    action.play();
+                });
+                mesh.userData.mixer = mixer;
             }
             mesh.position.fromArray(position);
             mesh.rotation.y = rotation;

--- a/js/zombie.js
+++ b/js/zombie.js
@@ -107,6 +107,10 @@ export function updateZombies(playerPosition, delta, collidableObjects = [], onP
     zombies.forEach(zombie => {
         if (zombie.userData.hp <= 0) return; // dead
 
+        if (zombie.userData.mixer) {
+            zombie.userData.mixer.update(delta);
+        }
+
         const stepBase = zombie.userData.speed * delta * 60;
         const attemptMove = move => {
             const nextPos = zombie.position.clone().add(move);


### PR DESCRIPTION
## Summary
- play animations from GLTF models
- update zombie loop to drive mixers each frame

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c38ac154a08333bb5deabf36e658b4