### PR TITLE
Enable zombie walk animation by cloning skinned models properly

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
     <div id="crosshair"></div>
     <script src="js/three.min.js"></script>
     <script src="js/GLTFLoader.js"></script>
+    <script src="js/SkeletonUtils.js"></script>
     <script type="module" src="js/main.js"></script>
 
     <script>

--- a/js/SkeletonUtils.js
+++ b/js/SkeletonUtils.js
@@ -1,0 +1,25 @@
+THREE.SkeletonUtils = {
+    clone: function(source) {
+        const sourceLookup = new Map();
+        const cloneLookup = new Map();
+        const clone = source.clone(true);
+        parallelTraverse(source, clone, (src, cloned) => {
+            sourceLookup.set(cloned, src);
+            cloneLookup.set(src, cloned);
+        });
+        source.traverse(function(src) {
+            if (!src.isSkinnedMesh) return;
+            const clonedMesh = cloneLookup.get(src);
+            const skeleton = src.skeleton;
+            const clonedBones = skeleton.bones.map(b => cloneLookup.get(b));
+            clonedMesh.bind(new THREE.Skeleton(clonedBones, skeleton.boneInverses), clonedMesh.matrixWorld);
+        });
+        return clone;
+        function parallelTraverse(a, b, callback) {
+            callback(a, b);
+            for (let i = 0; i < a.children.length; i++) {
+                parallelTraverse(a.children[i], b.children[i], callback);
+            }
+        }
+    }
+};

--- a/js/mapLoader.js
+++ b/js/mapLoader.js
@@ -124,7 +124,12 @@ export async function loadMap(scene) {
 
         // ---- NEW: Always allow zombies and model objects! ----
         if (rule && rule.model && gltfModels[type]) {
-            mesh = gltfModels[type].clone(true);
+            const sourceModel = gltfModels[type];
+            if (THREE.SkeletonUtils && THREE.SkeletonUtils.clone) {
+                mesh = THREE.SkeletonUtils.clone(sourceModel);
+            } else {
+                mesh = sourceModel.clone(true);
+            }
             mesh.traverse(node => {
                 if (node.isMesh) {
                     node.material = node.material.clone();


### PR DESCRIPTION
## Summary
- load SkeletonUtils to clone skinned glTF models
- clone zombie models with SkeletonUtils so animations play
- include SkeletonUtils script in HTML

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c39df6c21483338c67da87590b86a1