### PR TITLE
Ignore static GLTF animation clip

### DIFF
--- a/js/mapLoader.js
+++ b/js/mapLoader.js
@@ -20,7 +20,11 @@ function loadGLTFModel(id, modelPath) {
             modelPath,
             gltf => {
                 gltfModels[id] = gltf.scene;
-                gltfAnimations[id] = gltf.animations || [];
+                // Skip any default "Static" clip to prevent it from
+                // overriding the real animated clip (e.g. Mixamo export).
+                gltfAnimations[id] = (gltf.animations || []).filter(
+                    clip => clip.name.toLowerCase() !== 'static'
+                );
                 gltfLoadedFlags[id] = true;
                 resolve();
             },


### PR DESCRIPTION
## Summary
- Filter out `Static` animation clips when loading GLTF models so real animations (e.g. Mixamo) play

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c42fc235308333bd338e47891837ed