### PR TITLE
Log static zombie models without animations

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -124,6 +124,8 @@ export async function spawnZombiesFromMap(scene, mapObjects, models, materials) 
                 zombieMesh.userData.mixer = mixer;
                 zombieMesh.userData.actions = actions;
                 zombieMesh.userData._actionPlaying = false;
+            } else {
+                console.log('Zombie model has no animations; static model will not output animation logs.');
             }
 
             scene.add(zombieMesh);


### PR DESCRIPTION
## Summary
- Add console log warning when zombie model lacks animations to clarify that static models won't output animation logs

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c449169f9c833384a5046ed8119818