### PR TITLE
Reset zombie animation on hit

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -1,5 +1,6 @@
 import { updateHUD } from './hud.js';
 import { getLoadedObjects } from './mapLoader.js';
+import { getZombies, damageZombie } from './zombie.js';
 
 let pistol;
 let clipAmmo = 10;
@@ -165,6 +166,19 @@ export function updateBullets(deltaTime) {
                 const objBox = new THREE.Box3().setFromObject(obj);
                 if (bulletBox.intersectsBox(objBox)) {
                     hit = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hit) {
+            const zombies = getZombies();
+            for (const zombie of zombies) {
+                if (zombie.userData.hp <= 0) continue;
+                const zombieBox = new THREE.Box3().setFromObject(zombie);
+                if (bulletBox.intersectsBox(zombieBox)) {
+                    hit = true;
+                    damageZombie(zombie, 1);
                     break;
                 }
             }

--- a/js/zombie.js
+++ b/js/zombie.js
@@ -400,6 +400,9 @@ export function updateZombies(playerPosition, delta, collidableObjects = [], onP
 // Damage zombie
 export function damageZombie(zombie, dmg) {
     zombie.userData.hp -= dmg;
+    if (zombie.userData.hp > 0 && zombie.userData._movingAction) {
+        zombie.userData._movingAction.reset().play();
+    }
     if (zombie.userData.hp <= 0) {
         zombie.visible = false; // or play anim/remove
     }


### PR DESCRIPTION
## Summary
- Detect bullet collisions with zombies and apply damage
- Reset zombie movement animation when damaged to restart from the first frame

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c479da06088333b9044e9b2fed9c44