### PR TITLE
Fix zombie shooting to apply damage

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -162,6 +162,7 @@ export function updateBullets(deltaTime) {
 
         for (const obj of objects) {
             const rules = obj.userData.rules || {};
+            if (obj.userData.ai) continue;
             if (rules.collidable) {
                 const objBox = new THREE.Box3().setFromObject(obj);
                 if (bulletBox.intersectsBox(objBox)) {


### PR DESCRIPTION
## Summary
- Ignore AI-driven entities in bullet-to-object collision check so zombies can take damage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c47cbb64608333b34c92f0e3705d20