### PR TITLE
Keep zombies stationary but animated

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -230,10 +230,9 @@ function setZombieAnimation(zombie, moving) {
     }
 }
 
-// Basic AI: Only "active" if within spotDistance of player!
-// Make sure to pass [...getLoadedObjects(), ...getZombies()] as collidableObjects!
+// Update zombies: keep them stationary but let their animations run
+// Parameters are retained for API compatibility but are unused.
 export function updateZombies(playerPosition, delta, collidableObjects = [], onPlayerCollide = () => {}) {
-    const obstacleMap = buildObstacleMap(collidableObjects);
     zombies.forEach(zombie => {
         if (zombie.userData.hp <= 0) return; // dead
 
@@ -241,159 +240,8 @@ export function updateZombies(playerPosition, delta, collidableObjects = [], onP
             zombie.userData.mixer.update(delta);
         }
 
-        const stepBase = zombie.userData.speed * delta * 60;
-        let moved = false;
-        const attemptMove = move => {
-            const nextPos = zombie.position.clone().add(move);
-            const zombieBox = new THREE.Box3().setFromObject(zombie);
-            zombieBox.translate(move);
-            let collision = false;
-            for (const obj of collidableObjects) {
-                if (!obj.userData || !obj.userData.rules || !obj.userData.rules.collidable) continue;
-                if (obj === zombie) continue; // Don't collide with self
-                const objBox = new THREE.Box3().setFromObject(obj);
-                if (zombieBox.intersectsBox(objBox)) {
-                    collision = true;
-                    break;
-                }
-            }
-            if (!collision) {
-                zombie.position.copy(nextPos);
-                moved = true;
-                return true;
-            }
-
-            const axisMoves = [
-                new THREE.Vector3(move.x, 0, 0),
-                new THREE.Vector3(0, 0, move.z)
-            ];
-            for (const axisMove of axisMoves) {
-                if (axisMove.lengthSq() === 0) continue;
-                const axisBox = new THREE.Box3().setFromObject(zombie);
-                axisBox.translate(axisMove);
-                let axisCollision = false;
-                for (const obj of collidableObjects) {
-                    if (!obj.userData || !obj.userData.rules || !obj.userData.rules.collidable) continue;
-                    if (obj === zombie) continue;
-                    const objBox = new THREE.Box3().setFromObject(obj);
-                    if (axisBox.intersectsBox(objBox)) {
-                        axisCollision = true;
-                        break;
-                    }
-                }
-                if (!axisCollision) {
-                    zombie.position.add(axisMove);
-                    moved = true;
-                    return true;
-                }
-            }
-
-            zombie.position.add(move.clone().multiplyScalar(-1));
-            return false;
-        };
-
-        const spotDistance = zombie.userData.spotDistance || 8;
-        const dist = distanceXZ(zombie.position, playerPosition);
-
-        // --- Wander when player is far away ---
-        if (dist > spotDistance) {
-            zombie.userData.path = [];
-            if (!zombie.userData.wanderDir || zombie.userData.wanderTimeout < performance.now()) {
-                const angle = Math.random() * Math.PI * 2;
-                zombie.userData.wanderDir = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle));
-                zombie.userData.wanderTimeout = performance.now() + 2000 + Math.random() * 3000;
-            }
-
-            const step = stepBase * 0.5;
-            const move = zombie.userData.wanderDir.clone().setLength(step);
-            if (!attemptMove(move)) {
-                zombie.userData.wanderTimeout = 0; // pick new dir next frame
-            }
-            zombie.lookAt(zombie.position.x + zombie.userData.wanderDir.x, zombie.position.y, zombie.position.z + zombie.userData.wanderDir.z);
-            setZombieAnimation(zombie, moved);
-            return; // done with idle behaviour
-        }
-
-        // --- Follow path if one exists ---
-        if (zombie.userData.path && zombie.userData.path.length > 0) {
-            const target = zombie.userData.path[0];
-            const dir = new THREE.Vector3(target.x - zombie.position.x, 0, target.z - zombie.position.z);
-            if (dir.length() < 0.2) {
-                zombie.userData.path.shift();
-            } else {
-                dir.setLength(stepBase);
-                if (attemptMove(dir)) {
-                    zombie.lookAt(zombie.position.x + dir.x, zombie.position.y, zombie.position.z + dir.z);
-                    setZombieAnimation(zombie, moved);
-                    return;
-                } else {
-                    zombie.userData.path = [];
-                }
-            }
-        }
-
-        if (dist < 0.5) {
-            const pushDir = new THREE.Vector3().copy(playerPosition).sub(zombie.position);
-            pushDir.y = 0;
-            if (pushDir.lengthSq() > 0) {
-                pushDir.normalize();
-                const pushDistance = 1;
-                const pushAttempts = [
-                    pushDir.clone().multiplyScalar(pushDistance),
-                    new THREE.Vector3(-pushDir.z, 0, pushDir.x).multiplyScalar(pushDistance),
-                    new THREE.Vector3(pushDir.z, 0, -pushDir.x).multiplyScalar(pushDistance)
-                ];
-
-                for (const attempt of pushAttempts) {
-                    const nextPlayerPos = playerPosition.clone().add(attempt);
-                    // Use bounding boxes to check for collisions like the player movement code
-                    const playerBox = new THREE.Box3().setFromCenterAndSize(
-                        new THREE.Vector3(nextPlayerPos.x, 1.6, nextPlayerPos.z),
-                        new THREE.Vector3(0.5, 1.6, 0.5)
-                    );
-                    let collision = false;
-                    for (const obj of collidableObjects) {
-                        if (!obj.userData || !obj.userData.rules || !obj.userData.rules.collidable) continue;
-                        if (obj === zombie) continue;
-                        const objBox = new THREE.Box3().setFromObject(obj);
-                        if (playerBox.intersectsBox(objBox)) {
-                            collision = true;
-                            break;
-                        }
-                    }
-                    if (!collision) {
-                        playerPosition.copy(nextPlayerPos);
-                        break;
-                    }
-                }
-            }
-            onPlayerCollide();
-        }
-
-        // --- Move toward player using simple pathfinding ---
-        const toPlayer = new THREE.Vector3().copy(playerPosition).sub(zombie.position);
-        toPlayer.y = 0; // ignore vertical difference
-        if (toPlayer.length() > 0.1) {
-            const moveDir = toPlayer.clone().setLength(stepBase);
-            if (!attemptMove(moveDir)) {
-                const start = { x: Math.floor(zombie.position.x), z: Math.floor(zombie.position.z) };
-                const goal = { x: Math.floor(playerPosition.x), z: Math.floor(playerPosition.z) };
-                const path = findPath(start, goal, obstacleMap);
-                if (path.length > 0) {
-                    zombie.userData.path = path;
-                } else {
-                    const left = new THREE.Vector3(-moveDir.z, 0, moveDir.x).setLength(stepBase);
-                    if (!attemptMove(left)) {
-                        const right = left.clone().negate();
-                        attemptMove(right);
-                    }
-                }
-            } else {
-                zombie.lookAt(playerPosition.x, zombie.position.y, playerPosition.z);
-            }
-        }
-
-        setZombieAnimation(zombie, moved);
+        // Always treat zombies as "moving" so their walk animation plays
+        setZombieAnimation(zombie, true);
     });
 }
 


### PR DESCRIPTION
## Summary
- Keep zombies from moving while ensuring their walk animation continues to play

## Testing
- `node --check js/zombie.js`

------
https://chatgpt.com/codex/tasks/task_e_68c48545b8008333835e92143ebe3776