### PR TITLE
Use module-based Three.js for zombie models

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,9 +33,13 @@
 </head>
 <body>
     <div id="crosshair"></div>
-    <script src="js/three.min.js"></script>
-    <script src="js/GLTFLoader.js"></script>
-    <script type="module" src="js/main.js"></script>
+    <script type="module">
+        import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+        import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
+        window.THREE = THREE;
+        THREE.GLTFLoader = GLTFLoader;
+        import './js/main.js';
+    </script>
 
     <script>
         const audio = new Audio('sounds/background.mp3');

--- a/js/main.js
+++ b/js/main.js
@@ -14,7 +14,9 @@ const { camera, cameraContainer } = setupCamera();
 scene.add(cameraContainer);
 
 const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.outputColorSpace = THREE.SRGBColorSpace;
 document.body.appendChild(renderer.domElement);
 const canvas = renderer.domElement;
 


### PR DESCRIPTION
## Summary
- Load Three.js and GLTFLoader from CDN modules and expose them globally for the game
- Configure WebGL renderer with sRGB color space and pixel ratio for proper model rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c48ae58f1c8333ad4e0ade061d1e88