### PR TITLE
fix: resolve three.js imports via CDN

### DIFF
--- a/glb_viewer.html
+++ b/glb_viewer.html
@@ -21,15 +21,6 @@
     .file{display:inline-flex;align-items:center;gap:.5rem;padding:.35rem .6rem;border:1px dashed #1f2a44;border-radius:10px;background:#0b1220;cursor:pointer}
   </style>
 
-  <!-- Import map for THREE and addons (examples/jsm/) -->
-  <script type="importmap">
-  {
-    "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
-    }
-  }
-  </script>
 </head>
 <body>
   <div id="ui">
@@ -68,9 +59,9 @@
   <div id="view"></div>
 
   <script type="module">
-    import * as THREE from 'three';
-    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-    import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+    import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+    import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
 
     // --- Setup ---
     const container = document.getElementById('view');

--- a/zombie_model_viewer.html
+++ b/zombie_model_viewer.html
@@ -9,14 +9,6 @@
     select { padding: 4px; }
     canvas { display: block; }
   </style>
-  <script type="importmap">
-  {
-    "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
-    }
-  }
-  </script>
 </head>
 <body>
     <div id="ui">
@@ -28,9 +20,9 @@
   <canvas id="view"></canvas>
 
   <script type="module">
-    import * as THREE from 'three';
-    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-    import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+    import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+    import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
 
     const canvas = document.getElementById('view');
     const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });


### PR DESCRIPTION
## Summary
- replace import maps and bare `three` specifiers in HTML viewers with CDN-based imports

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c48d1cc83883338ed0a580c1b6d4ac