### PR TITLE
fix three module import

### DIFF
--- a/glb_viewer.html
+++ b/glb_viewer.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>GLB Viewer — jsDelivr Import Map</title>
+  <link rel="icon" href="favicon.ico" />
   <style>
     html,body{height:100%;margin:0;background:#0b1220;color:#e5e7eb;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;overflow:hidden}
     #ui{position:fixed;left:0;top:0;bottom:0;width:280px;box-sizing:border-box;padding:10px;background:#0e1629;border-right:1px solid #1f2a44;z-index:2}
@@ -21,6 +22,14 @@
     .file{display:inline-flex;align-items:center;gap:.5rem;padding:.35rem .6rem;border:1px dashed #1f2a44;border-radius:10px;background:#0b1220;cursor:pointer}
   </style>
 
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+    }
+  }
+  </script>
 </head>
 <body>
   <div id="ui">
@@ -59,9 +68,9 @@
   <div id="view"></div>
 
   <script type="module">
-    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
-    import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js';
-    import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
+    import * as THREE from 'three';
+    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+    import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
     // --- Setup ---
     const container = document.getElementById('view');

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title>3D First-Person Game</title>
+    <link rel="icon" href="favicon.ico">
     <style>
         body { margin: 0; overflow: hidden; }
         canvas { display: block; }
@@ -30,12 +31,20 @@
             to { opacity: 0; transform: scale(2); }
         }
     </style>
+    <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+      }
+    }
+    </script>
 </head>
 <body>
     <div id="crosshair"></div>
     <script type="module">
-        import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
-        import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
+        import * as THREE from 'three';
+        import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
         window.THREE = THREE;
         THREE.GLTFLoader = GLTFLoader;
         import './js/main.js';

--- a/zombie_model_viewer.html
+++ b/zombie_model_viewer.html
@@ -3,12 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <title>Zombie Model Viewer</title>
+  <link rel="icon" href="favicon.ico" />
   <style>
     html, body { margin: 0; height: 100%; overflow: hidden; }
     #ui { position: fixed; top: 10px; left: 10px; z-index: 1; display: flex; gap: 6px; flex-wrap: wrap; }
     select { padding: 4px; }
     canvas { display: block; }
   </style>
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+    }
+  }
+  </script>
 </head>
 <body>
     <div id="ui">
@@ -20,9 +29,9 @@
   <canvas id="view"></canvas>
 
   <script type="module">
-    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
-    import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js';
-    import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
+    import * as THREE from 'three';
+    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+    import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
     const canvas = document.getElementById('view');
     const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });


### PR DESCRIPTION
## Summary
- add import maps to resolve bare `three` specifiers
- switch to CDN-based module imports using `three` and addon paths
- include favicon links to stop unnecessary 404s

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c48f5d170c833387d06a3f08c04bf4