### PR TITLE
Fix THREE undefined by delaying main module import

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,9 +45,15 @@
     <script type="module">
         import * as THREE from 'three';
         import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+
+        // Expose THREE globally so non-module scripts can use it.
         window.THREE = THREE;
         THREE.GLTFLoader = GLTFLoader;
-        import './js/main.js';
+
+        // Dynamically import the main game script after THREE is defined
+        // to ensure modules like mapLoader.js can access the global THREE
+        // object without encountering "THREE is not defined" errors.
+        import('./js/main.js');
     </script>
 
     <script>


### PR DESCRIPTION
## Summary
- ensure main module loads after exposing THREE globally to avoid "THREE is not defined" errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4911687f8833388ddb119fcfca2ef