### PR TITLE
Fix GLTFLoader import error by using mutable THREE global

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,9 +46,10 @@
         import * as THREE from 'three';
         import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
-        // Expose THREE globally so non-module scripts can use it.
-        window.THREE = THREE;
-        THREE.GLTFLoader = GLTFLoader;
+        // Expose a mutable THREE global so non-module scripts can use it.
+        // The module namespace object returned by the import is read-only,
+        // so we create a plain object copy and attach GLTFLoader explicitly.
+        window.THREE = { ...THREE, GLTFLoader };
 
         // Dynamically import the main game script after THREE is defined
         // to ensure modules like mapLoader.js can access the global THREE


### PR DESCRIPTION
## Summary
- Use a plain object copy for `THREE` and attach `GLTFLoader` so global code can access the loader without mutating the module namespace

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c493b582648333a7d8039d0140f0cf