### PR TITLE
Normalize zombie model size

### DIFF
--- a/js/mapLoader.js
+++ b/js/mapLoader.js
@@ -9,6 +9,7 @@ let textures = {};
 let gltfModels = {};
 let gltfAnimations = {};
 let gltfLoadedFlags = {};
+const DEFAULT_ZOMBIE_SIZE = [0.7, 1.8, 0.7];
 
 const textureLoader = new THREE.TextureLoader();
 const gltfLoader = new THREE.GLTFLoader();
@@ -71,7 +72,7 @@ export async function loadMap(scene) {
             collidable: obj.collidable === true,
             model: obj.model || null,
             ai: obj.ai === true || obj.isZombie === true, // extra fallback
-            geometry: obj.size ? obj.size.slice() : [1,1,1],
+            geometry: obj.size ? obj.size.slice() : ((obj.ai === true || obj.isZombie === true) ? DEFAULT_ZOMBIE_SIZE.slice() : [1,1,1]),
             color: obj.color || '#999999',
             texture: obj.texture || null
         };

--- a/js/zombie.js
+++ b/js/zombie.js
@@ -2,6 +2,7 @@
 
 let zombies = [];
 let zombieTypeIds = null;
+const DEFAULT_ZOMBIE_SIZE = [0.7, 1.8, 0.7];
 
 // Helper for horizontal distance (ignore Y axis)
 function distanceXZ(a, b) {
@@ -149,17 +150,16 @@ export async function spawnZombiesFromMap(scene, mapObjects, models, materials) 
 
             // Scale model to match defined geometry size (so zombies aren't gigantic)
             const rule = zombieMesh.userData && zombieMesh.userData.rules;
-            if (rule && rule.geometry) {
-                const box = new THREE.Box3().setFromObject(zombieMesh);
-                const size = new THREE.Vector3();
-                box.getSize(size);
-                if (size.x > 0 && size.y > 0 && size.z > 0) {
-                    zombieMesh.scale.set(
-                        rule.geometry[0] / size.x,
-                        rule.geometry[1] / size.y,
-                        rule.geometry[2] / size.z
-                    );
-                }
+            const targetSize = (rule && rule.geometry) ? rule.geometry : DEFAULT_ZOMBIE_SIZE;
+            const box = new THREE.Box3().setFromObject(zombieMesh);
+            const size = new THREE.Vector3();
+            box.getSize(size);
+            if (size.x > 0 && size.y > 0 && size.z > 0) {
+                zombieMesh.scale.set(
+                    targetSize[0] / size.x,
+                    targetSize[1] / size.y,
+                    targetSize[2] / size.z
+                );
             }
 
             if (models[objType].animations && models[objType].animations.length > 0) {


### PR DESCRIPTION
## Summary
- Ensure zombies without explicit geometry auto-scale to a default human-sized volume
- Provide default geometry values for AI objects so imported zombies don't appear oversized

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c49523fac48333898cfa474a473db3