### PR TITLE
Animate zombies

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -197,8 +197,8 @@ export function updateZombies(delta) {
         if (zombie.userData.mixer) {
             zombie.userData.mixer.update(delta);
         }
-        // Always play idle animation
-        setZombieAnimation(zombie, false);
+        // Play the default animation so zombies aren't static
+        setZombieAnimation(zombie, true);
     });
 }
 


### PR DESCRIPTION
## Summary
- Start default animation for zombies so they aren't static

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ba81dfbc8333a7869e214d43048c