### PR TITLE
Implement basic zombie pathfinding and melee attack

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -215,8 +215,8 @@ function animate() {
 
   updateTorchTarget(camera, torch);
 
-  // ---- Zombie animation update ----
-  updateZombies(delta);
+  // ---- Zombie animation & AI update ----
+  updateZombies(delta, cameraContainer, handlePlayerHit);
 
   checkPickups(cameraContainer, scene);
   updateBullets(delta);


### PR DESCRIPTION
## Summary
- Add zombie AI that chases the player when in line of sight and wanders otherwise
- Perform collision checks, simple line-of-sight and melee attack cooldowns
- Update main loop to pass player info for zombie AI

## Testing
- `node --check game/js/zombie.js`
- `node --check game/js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bda14a7083339b3cdf1d59bbbc58