### PR TITLE
Cache zombie model bounding boxes to reduce load lag

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -93,27 +93,33 @@ export async function spawnZombiesFromMap(scene, mapObjects, models, materials) 
             const rule = zombieMesh.userData && zombieMesh.userData.rules;
             const targetSize = (rule && rule.geometry) ? rule.geometry : DEFAULT_ZOMBIE_SIZE;
 
-            // Initial bounding box
-            zombieMesh.updateMatrixWorld(true);
-            const box = new THREE.Box3().setFromObject(zombieMesh);
-            const size = new THREE.Vector3();
-            box.getSize(size);
-
-            // If any dimension is zero, recompute using mesh geometries to avoid
-            // oversized models when bounding boxes are missing (e.g. skinned meshes)
-            if (size.x <= 0 || size.y <= 0 || size.z <= 0) {
-                box.makeEmpty();
-                zombieMesh.traverse(node => {
-                    if (node.isMesh && node.geometry) {
-                        node.geometry.computeBoundingBox();
-                        const nodeBox = node.geometry.boundingBox.clone();
-                        nodeBox.applyMatrix4(node.matrixWorld);
-                        box.union(nodeBox);
-                    }
-                });
+            // Compute and cache original model bounding box once per zombie type
+            if (!models[objType]._size) {
+                const src = models[objType].scene;
+                src.updateMatrixWorld(true);
+                const box = new THREE.Box3().setFromObject(src);
+                const size = new THREE.Vector3();
                 box.getSize(size);
+
+                // If any dimension is zero, recompute using mesh geometries to avoid
+                // oversized models when bounding boxes are missing (e.g. skinned meshes)
+                if (size.x <= 0 || size.y <= 0 || size.z <= 0) {
+                    box.makeEmpty();
+                    src.traverse(node => {
+                        if (node.isMesh && node.geometry) {
+                            node.geometry.computeBoundingBox();
+                            const nodeBox = node.geometry.boundingBox.clone();
+                            nodeBox.applyMatrix4(node.matrixWorld);
+                            box.union(nodeBox);
+                        }
+                    });
+                    box.getSize(size);
+                }
+
+                models[objType]._size = size;
             }
 
+            const size = models[objType]._size;
             if (size.x > 0 && size.y > 0 && size.z > 0) {
                 zombieMesh.scale.set(
                     targetSize[0] / size.x,


### PR DESCRIPTION
## Summary
- Cache computed bounding boxes for zombie models to avoid reprocessing on every spawn.
- Reuse cached size to scale zombie clones efficiently.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c0f51e4883338dc4fec2c343b002