### PR TITLE
Add knockback effect when zombies hit player

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -49,9 +49,13 @@ function applyShake(delta) {
   }
 }
 
-function handlePlayerHit() {
+function handlePlayerHit(dir) {
   hitSound.currentTime = 0;
   hitSound.play();
+  if (dir) {
+    const knockback = 1 + Math.random() * 2;
+    cameraContainer.position.addScaledVector(dir, knockback);
+  }
   movement.setEnabled(false);
   setTimeout(() => movement.setEnabled(true), 500);
   spawnSplash();

--- a/js/zombie.js
+++ b/js/zombie.js
@@ -260,7 +260,7 @@ export function updateZombies(delta, playerObj, onPlayerHit) {
             zombie.userData._nextAttack = zombie.userData._nextAttack ?? 0;
             zombie.userData._nextAttack -= delta;
             if (dist < 1.2 && zombie.userData._nextAttack <= 0) {
-                if (typeof onPlayerHit === 'function') onPlayerHit();
+                if (typeof onPlayerHit === 'function') onPlayerHit(dir.clone());
                 zombie.userData._nextAttack = zombie.userData.attackCooldown;
             }
         } else {


### PR DESCRIPTION
## Summary
- Push player back 1-3 yards when struck by a zombie
- Pass attack direction from zombie AI to player hit handler

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c36001308333b155cdd6760bf95a