### PR TITLE
Prevent player from being knocked into walls

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -54,7 +54,16 @@ function handlePlayerHit(dir) {
   hitSound.play();
   if (dir) {
     const knockback = 1 + Math.random() * 2;
-    cameraContainer.position.addScaledVector(dir, knockback);
+    const basePos = cameraContainer.position.clone();
+    let step = knockback;
+    let target = basePos.clone().addScaledVector(dir, step);
+    if (movement.checkCollision) {
+      while (step > 0 && movement.checkCollision(target)) {
+        step *= 0.5;
+        target = basePos.clone().addScaledVector(dir, step);
+      }
+    }
+    cameraContainer.position.copy(target);
   }
   movement.setEnabled(false);
   setTimeout(() => movement.setEnabled(true), 500);

--- a/js/movement.js
+++ b/js/movement.js
@@ -60,5 +60,5 @@ export function setupMovement(cameraContainer, camera) {
         enabled = val;
     }
 
-    return { update, setEnabled };
+    return { update, setEnabled, checkCollision };
 }


### PR DESCRIPTION
## Summary
- Expose movement collision helper
- Clamp zombie knockback to valid positions to stop wall clipping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c5010910833381988419e7ba79a3