### PR TITLE
Rotate zombies toward movement direction

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -239,6 +239,11 @@ export function updateZombies(delta, playerObj, onPlayerHit) {
         const proposed = zombie.position.clone().addScaledVector(zombie.userData._wanderDir, zombie.userData.speed * 0.5);
         if (!checkZombieCollision(zombie, proposed, collidableObjects)) {
             zombie.position.copy(proposed);
+            // Rotate to face the direction of movement
+            zombie.rotation.y = Math.atan2(
+                zombie.userData._wanderDir.x,
+                zombie.userData._wanderDir.z
+            );
             moving = true;
         } else {
             zombie.userData._wanderTime = 0; // pick new direction next frame


### PR DESCRIPTION
## Summary
- Rotate wandering zombies to face the direction they're moving.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ce4e22a083338e5dac3f14bc9f29