### PR TITLE
Ignore zombie self-collisions

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -232,7 +232,8 @@ export function updateZombies(delta, playerObj, onPlayerHit) {
     const allObjects = getLoadedObjects();
     const collidableObjects = allObjects.filter(o => {
         const rules = (o.userData && o.userData.rules) ? o.userData.rules : {};
-        return rules.collidable;
+        // Ignore other zombies so they don't block each other
+        return rules.collidable && !zombies.includes(o);
     });
 
     zombies.forEach(zombie => {


### PR DESCRIPTION
## Summary
- prevent zombies from treating other zombies as collision obstacles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d975f088833388b5c99a8ddb7252