### PR TITLE
Add melee attack with zombie knockback

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -6,7 +6,7 @@ import { initHUD, updateHUD } from './hud.js';
 import { addPistolToCamera, shootPistol, updateBullets } from './pistol.js';
 import { initCrosshair, drawCrosshair, positionCrosshair } from './crosshair.js';
 import { setupZoom } from './zoom.js';
-import { spawnZombiesFromMap, updateZombies } from './zombie.js';
+import { spawnZombiesFromMap, updateZombies, playerMeleeAttack } from './zombie.js';
 
 // --- Scene and Camera setup ---
 const scene = new THREE.Scene();
@@ -205,6 +205,10 @@ addPistolToCamera(camera);
 
 document.addEventListener('mousedown', (e) => {
   if (e.button === 0) shootPistol(scene, camera);
+});
+
+document.addEventListener('keydown', (e) => {
+  if (e.code === 'KeyF') playerMeleeAttack(cameraContainer);
 });
 
 window.addEventListener('resize', () => {


### PR DESCRIPTION
## Summary
- Allow players to perform a melee attack with `F`
- Damage nearby zombies and push them back about half a foot
- Restart zombie animation on hit for feedback

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4dd6d77dc8333bae3dfc1a545ede0