### PR TITLE
Add knockback and animation reset when zombies are shot

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -179,7 +179,7 @@ export function updateBullets(deltaTime) {
                 const zombieBox = new THREE.Box3().setFromObject(zombie);
                 if (bulletBox.intersectsBox(zombieBox)) {
                     hit = true;
-                    damageZombie(zombie, 1);
+                    damageZombie(zombie, 1, bullet.userData.velocity);
                     break;
                 }
             }

--- a/js/zombie.js
+++ b/js/zombie.js
@@ -353,12 +353,25 @@ export function updateZombies(delta, playerObj, onPlayerHit) {
     });
 }
 
-// Damage zombie
-export function damageZombie(zombie, dmg) {
+// Damage zombie and apply knockback/animation reset
+export function damageZombie(zombie, dmg, hitDir) {
+    // Reduce health
     zombie.userData.hp -= dmg;
-    if (zombie.userData.hp > 0 && zombie.userData._movingAction) {
-        zombie.userData._movingAction.reset().play();
+
+    // Apply a small knockback in the direction of the hit
+    if (hitDir) {
+        const kb = hitDir.clone().setY(0).normalize().multiplyScalar(0.5);
+        zombie.position.add(kb);
     }
+
+    // Reset animation so the zombie visibly reacts
+    if (zombie.userData._movingAction) {
+        zombie.userData._movingAction.stop();
+        zombie.userData._movingAction.reset().play();
+        zombie.userData._actionPlaying = true;
+    }
+
+    // Hide zombie if out of health
     if (zombie.userData.hp <= 0) {
         zombie.visible = false; // or play anim/remove
     }


### PR DESCRIPTION
## Summary
- Apply 0.5‑unit knockback and reset animation when a zombie takes bullet damage
- Pass bullet direction to damage logic during collision to drive knockback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4df3c01188333a01d2235a1fec7a7