### PR TITLE
Increase zombie knockback on bullet hit

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -371,9 +371,9 @@ export function damageZombie(zombie, dmg, hitDir) {
     // Reduce health
     zombie.userData.hp -= dmg;
 
-    // Apply a knockback impulse in the direction of the hit
+    // Apply a knockback impulse in the direction of the hit (~2 feet)
     if (hitDir) {
-        const kb = hitDir.clone().setY(0).normalize().multiplyScalar(0.5);
+        const kb = hitDir.clone().setY(0).normalize().multiplyScalar(2);
         if (!zombie.userData.knockback) {
             zombie.userData.knockback = new THREE.Vector3();
         }


### PR DESCRIPTION
## Summary
- Boost zombie knockback impulse to roughly 2 feet when struck by bullets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e28c184883338df58de050486c11