### PR TITLE
Ensure zombies register bullet hits

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -160,8 +160,8 @@ export async function spawnZombiesFromMap(scene, mapObjects, models, materials) 
         zombieMesh.userData.speed = zombieMesh.userData.speed ?? 0.01;
         zombieMesh.userData.attackCooldown = zombieMesh.userData.attackCooldown ?? 1;
         zombieMesh.userData.turnSpeed = zombieMesh.userData.turnSpeed ?? 5;
-        // AI disabled: mark zombie as non-AI
-        zombieMesh.userData.ai = false;
+        // Mark zombie objects for AI interactions (e.g., bullet hit tests)
+        zombieMesh.userData.ai = true;
         zombies.push(zombieMesh);
     }
 }


### PR DESCRIPTION
## Summary
- Mark spawned zombie meshes with `ai = true` so bullets skip environment collision checks and apply damage to zombies

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e35ed2f08333a20e191762557c17