### PR TITLE
Add blood effect when zombies are hit

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -6,7 +6,7 @@ import { initHUD, updateHUD } from './hud.js';
 import { addPistolToCamera, shootPistol, updateBullets } from './pistol.js';
 import { initCrosshair, drawCrosshair, positionCrosshair } from './crosshair.js';
 import { setupZoom } from './zoom.js';
-import { spawnZombiesFromMap, updateZombies } from './zombie.js';
+import { spawnZombiesFromMap, updateZombies, updateBloodEffects } from './zombie.js';
 
 // --- Scene and Camera setup ---
 const scene = new THREE.Scene();
@@ -250,6 +250,7 @@ function animate() {
 
   // ---- Zombie animation & AI update ----
   updateZombies(delta, cameraContainer, handlePlayerHit);
+  updateBloodEffects(delta);
 
   checkPickups(cameraContainer, scene);
   updateBullets(delta);


### PR DESCRIPTION
## Summary
- load blood effect model and spawn scaled effect when zombies take damage
- animate blood effects flying away from the hit zombie
- update main loop to render and update blood effects

## Testing
- `node --check js/zombie.js && echo "zombie.js ok"`
- `node --check js/main.js && echo "main.js ok"`


------
https://chatgpt.com/codex/tasks/task_e_68c4e9cc17348333896ed0de26696ec5