### PR TITLE
feat: add zombie death effects

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -32,6 +32,19 @@ function spawnSplash() {
   setTimeout(() => splash.remove(), 500);
 }
 
+// Flash effect when a zombie is killed
+function spawnKillFlash() {
+  const flash = document.createElement('div');
+  flash.className = 'splash';
+  flash.style.left = '50%';
+  flash.style.top = '50%';
+  flash.style.marginLeft = '-25px';
+  flash.style.marginTop = '-25px';
+  flash.style.background = 'rgba(255,255,255,0.5)';
+  document.body.appendChild(flash);
+  setTimeout(() => flash.remove(), 300);
+}
+
 let shakeTime = 0;
 function triggerShake() {
   shakeTime = 0.3;
@@ -205,6 +218,12 @@ addPistolToCamera(camera);
 
 document.addEventListener('mousedown', (e) => {
   if (e.button === 0) shootPistol(scene, camera);
+});
+
+// React to zombie deaths with a flash and screen shake
+window.addEventListener('zombieKilled', () => {
+  spawnKillFlash();
+  triggerShake();
 });
 
 window.addEventListener('resize', () => {

--- a/js/zombie.js
+++ b/js/zombie.js
@@ -403,9 +403,21 @@ export function damageZombie(zombie, dmg, hitDir, hitPos) {
         zombie.userData._actionPlaying = true;
     }
 
-    // Hide zombie if out of health
-    if (zombie.userData.hp <= 0) {
-        zombie.visible = false; // or play anim/remove
+    // Handle death: keep corpse, lay it down, and notify listeners
+    if (zombie.userData.hp <= 0 && !zombie.userData._dead) {
+        zombie.userData._dead = true;
+
+        // Rotate the zombie so the body lies flat on the ground
+        zombie.rotation.x = -Math.PI / 2;
+
+        // Drop the corpse slightly so it rests on the floor
+        const size = (zombie.userData && zombie.userData.rules && zombie.userData.rules.geometry)
+            ? zombie.userData.rules.geometry
+            : DEFAULT_ZOMBIE_SIZE;
+        zombie.position.y -= size[1] / 2;
+
+        // Emit an event so the main game can react (screen shake, etc.)
+        window.dispatchEvent(new CustomEvent('zombieKilled', { detail: { zombie } }));
     }
 }
 


### PR DESCRIPTION
## Summary
- Keep slain zombies visible, drop them to the ground, and emit a `zombieKilled` event
- Add flash and screen shake reactions when a zombie dies

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f12ed2588333915e08d52b984a07