### PR TITLE
fix zombie floating above ground

### DIFF
--- a/js/mapLoader.js
+++ b/js/mapLoader.js
@@ -42,7 +42,11 @@ function loadGLTFModel(id, modelPath) {
 function applyPosition(mesh, position, rule) {
     mesh.position.fromArray(position);
     if (position[1] === 0.5 && rule && rule.geometry) {
-        mesh.position.y = rule.geometry[1] / 2;
+        if (rule.ai && rule.model) {
+            mesh.position.y = 0;
+        } else {
+            mesh.position.y = rule.geometry[1] / 2;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust position logic to keep zombie models at ground level

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fa028abc8333914f32aae90345c3