### PR TITLE
fix: ensure pistol is rendered

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -20,6 +20,8 @@ export function addPistolToCamera(camera) {
         'models/pistol.glb',
         gltf => {
             pistol = gltf.scene;
+            // Attach the pistol to the camera and ensure it's always rendered
+            pistol.traverse(obj => obj.frustumCulled = false);
             pistol.position.set(0.4, -0.3, -0.7);
             camera.add(pistol);
         },


### PR DESCRIPTION
## Summary
- prevent pistol from being frustum culled so it's always visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c58fbcecac8333946af0be4ffd765c