### PR TITLE
Fix pistol orientation so gun renders correctly

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -23,6 +23,7 @@ export function addPistolToCamera(camera) {
             // Attach the pistol to the camera and ensure it's always rendered
             pistol.traverse(obj => obj.frustumCulled = false);
             pistol.position.set(0.4, -0.3, -0.7);
+            pistol.rotation.y = Math.PI; // Ensure pistol faces the camera
             camera.add(pistol);
         },
         undefined,


### PR DESCRIPTION
## Summary
- rotate pistol model 180° so it's facing the camera, making the weapon visible in first-person view

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*
- `node --check js/pistol.js`

------
https://chatgpt.com/codex/tasks/task_e_68c59197ee108333bb9ae1e560d4a26f