### PR TITLE
Add idle and jog pistol animations

### DIFF
--- a/js/movement.js
+++ b/js/movement.js
@@ -1,5 +1,5 @@
 import { getLoadedObjects } from './mapLoader.js';
-import { reloadAmmo } from './pistol.js';
+import { reloadAmmo, setPistolMoving } from './pistol.js';
 
 export function setupMovement(cameraContainer, camera) {
     const keys = {};
@@ -54,6 +54,9 @@ export function setupMovement(cameraContainer, camera) {
         if (!checkCollision(proposed)) {
             cameraContainer.position.copy(proposed);
         }
+
+        const isMoving = keys['KeyW'] || keys['KeyA'] || keys['KeyS'] || keys['KeyD'];
+        setPistolMoving(!!isMoving);
     }
 
     function setEnabled(val) {


### PR DESCRIPTION
## Summary
- Play pistol idle and jog animations via Three.js AnimationMixer
- Switch pistol animation based on player movement state

## Testing
- `node --check js/pistol.js`
- `node --check js/movement.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5991f87d88333b1f5cdd180039cad