### PR TITLE
Require manual reload except when empty

### DIFF
--- a/js/movement.js
+++ b/js/movement.js
@@ -8,7 +8,7 @@ export function setupMovement(cameraContainer, camera) {
         keys[e.code] = true;
 
         if (e.code === 'KeyR') {
-            reloadAmmo(10);
+            reloadAmmo();
             console.log('?? Reloaded!');
         }
     });

--- a/js/pistol.js
+++ b/js/pistol.js
@@ -135,16 +135,9 @@ export function shootPistol(scene, camera) {
     console.log(`Bang! Ammo: ${clipAmmo}`);
     updateHUD(clipAmmo, 100);
 
-    // ?? Auto-reload if not full
+    // Allow shooting again after short delay
     setTimeout(() => {
-        if (clipAmmo < maxClip && !isReloading) {
-            console.log("?? Auto-reloading: clip not full.");
-            reloadAmmo(() => {
-                canShoot = true;
-            });
-        } else {
-            canShoot = true;
-        }
+        canShoot = true;
     }, 170);
 }
 


### PR DESCRIPTION
## Summary
- Remove automatic reload after each shot; only re-enable firing after a short delay
- Trigger reload when pressing **R** key instead of passing stray argument

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c59bbb0c708333b9cc6086b1e51f5a