### PR TITLE
Hide stray bullet meshes

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -63,7 +63,15 @@ export function addPistolToCamera(camera) {
             }
 
             // Attach the pistol to the camera and ensure it's always rendered
-            pistol.traverse(obj => obj.frustumCulled = false);
+            pistol.traverse(obj => {
+                obj.frustumCulled = false;
+
+                // Hide loose bullet/shell meshes that appear in first person view
+                const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+                if (mats.some(m => m && m.name && /bullet|shell/i.test(m.name))) {
+                    obj.visible = false;
+                }
+            });
             pistol.position.set(0.4, -0.3, -0.7);
             pistol.rotation.y = Math.PI; // Ensure pistol faces the camera
             camera.add(pistol);


### PR DESCRIPTION
## Summary
- Hide bullet and shell meshes in pistol model to remove stray clip visible in first-person view

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a8a76b188333a22adb363d193cad