### PR TITLE
Allow idle jump animation to play fully

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -261,6 +261,17 @@ export function setPistolMoving(moving) {
     if (!pistolMixer || !idleAction || !jogAction || isReloading) return;
 
     const target = moving ? jogAction : idleAction;
+
+    // Allow the jump animation to finish when the player is idle.
+    // Movement.js calls this function every frame, which previously
+    // caused the idle jump clip to be interrupted and skipped after
+    // only a few frames.  If we're not moving and the jump animation
+    // is currently playing, leave it alone so it can play its full
+    // duration.
+    if (!moving && currentAction === jumpAction) {
+        return;
+    }
+
     if (currentAction === target) return;
 
     currentAction?.fadeOut(0.2);
@@ -269,7 +280,7 @@ export function setPistolMoving(moving) {
 
     if (moving) {
         clearTimeout(jumpTimeout);
-    } else {
+    } else if (currentAction !== jumpAction) {
         scheduleRandomJump();
     }
 }


### PR DESCRIPTION
## Summary
- Prevent setPistolMoving from interrupting idle jump clip
- Only schedule random idle jumps when not already jumping

## Testing
- `node --check js/pistol.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5b09b562083338d8c1e22ce696906