### PR TITLE
Normalize reload speed during movement

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -236,7 +236,7 @@ export function reloadAmmo(onReloaded) {
 
     if (clipAmmo === 0 && reloadCompleteAction) {
         console.log("? Reloading from empty...");
-        reloadCompleteAction.timeScale = isMoving ? 1 / 3 : 1;
+        reloadCompleteAction.timeScale = 1;
         reloadCompleteAction.reset().play();
         const duration = (reloadCompleteAction.getClip().duration / reloadCompleteAction.timeScale) * 1000;
         reloadTimeout = setTimeout(() => {
@@ -253,9 +253,9 @@ export function reloadAmmo(onReloaded) {
 
     console.log("? Reloading one by one...");
 
-    const intervalDuration = isMoving ? 1200 : 400;
+    const intervalDuration = 400;
     if (reloadFastAction) {
-        reloadFastAction.timeScale = isMoving ? 1 / 3 : 1;
+        reloadFastAction.timeScale = 1;
         reloadFastAction.reset().play();
     }
 


### PR DESCRIPTION
## Summary
- Remove slower reload when player is moving
- Keep reload animation speed consistent regardless of movement

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bb3205f083339cf2ea35a9460050