### PR TITLE
Allow cancelling full pistol reload

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -138,7 +138,7 @@ export function shootPistol(scene, camera) {
     }
 
     if (isReloading) {
-        console.log("? Reload canceled + firing...");
+        console.log(clipAmmo > 0 ? "? Reload canceled + firing..." : "? Reload canceled.");
         isReloading = false;
         if (reloadInterval) clearInterval(reloadInterval);
         if (reloadTimeout) clearTimeout(reloadTimeout);
@@ -147,7 +147,9 @@ export function shootPistol(scene, camera) {
         canShoot = true;
         setPistolMoving(isMoving);
 
-        setTimeout(() => shootPistol(scene, camera), 0);
+        if (clipAmmo > 0) {
+            setTimeout(() => shootPistol(scene, camera), 0);
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary
- Prevent pistol reload animation from auto-restarting when cancelled with an empty clip

## Testing
- `node --check js/pistol.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5bfe60a088333a387dc9883412e51