### PR TITLE
Auto reload when clip empty

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -204,9 +204,16 @@ export function shootPistol(scene, camera) {
     console.log(`Bang! Ammo: ${clipAmmo}`);
     updateHUD(clipAmmo, 100);
 
-    // Allow shooting again after short delay
+    // Allow shooting again after short delay or trigger reload when empty
     setTimeout(() => {
-        canShoot = true;
+        if (clipAmmo === 0) {
+            console.log("?? Empty clip. Auto-reloading...");
+            reloadAmmo(() => {
+                canShoot = true;
+            });
+        } else {
+            canShoot = true;
+        }
     }, 170);
 }
 


### PR DESCRIPTION
## Summary
- Trigger pistol reload automatically once the clip is emptied after firing.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c3e8f9b48333961c4ea90b719a03