### PR TITLE
Ignore fire input during empty reload

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -138,6 +138,10 @@ export function shootPistol(scene, camera) {
     }
 
     if (isReloading) {
+        if (clipAmmo === 0) {
+            console.log("? Reloading...");
+            return;
+        }
         console.log(clipAmmo > 0 ? "? Reload canceled + firing..." : "? Reload canceled.");
         isReloading = false;
         if (reloadInterval) {


### PR DESCRIPTION
## Summary
- ignore fire input while reloading from empty to prevent canceling the full reload

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/pistol.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5d1fe64a88333be521f2a3b9fa2ed