### PR TITLE
Disable depth testing for pistol

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -112,8 +112,20 @@ export function addPistolToCamera(camera) {
             pistol.traverse(obj => {
                 obj.frustumCulled = false;
 
+                const mats = Array.isArray(obj.material)
+                    ? obj.material
+                    : obj.material
+                        ? [obj.material]
+                        : [];
+
+                for (const mat of mats) {
+                    if (!mat) continue;
+                    // Disable depth testing so the pistol always renders in front
+                    mat.depthTest = false;
+                    mat.depthWrite = false;
+                }
+
                 // Hide loose bullet/shell meshes that appear in first person view
-                const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
                 if (mats.some(m => m && m.name && /bullet|shell/i.test(m.name))) {
                     obj.visible = false;
                 }


### PR DESCRIPTION
## Summary
- Render pistol without depth testing to keep it visible even when near walls.

## Testing
- `node --check js/pistol.js`
- `npm test` *(fails: enoent could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d7a5b6988333bba806fe3451aee2