### PR TITLE
fix: prevent torch from going dark against walls

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -130,7 +130,8 @@ const torch = new THREE.SpotLight(
     TORCH_PENUMBRA,
     TORCH_DECAY
 );
-torch.position.set(0, 0.5, 0); // Above player's eyes
+// Offset slightly forward so walls remain lit when the player is up close
+torch.position.set(0, 0.5, -0.2); // Above player's eyes
 camera.add(torch);
 torch.layers.enable(1);
 scene.add(torch.target);

--- a/js/torch.js
+++ b/js/torch.js
@@ -19,7 +19,8 @@ export function setupTorch(camera, scene) {
     torch = new THREE.SpotLight(
         TORCH_COLOR, TORCH_INTENSITY, TORCH_DISTANCE, TORCH_ANGLE, TORCH_PENUMBRA, TORCH_DECAY
     );
-    torch.position.set(0, 0.5, 0);
+    // Place the light slightly in front of the camera so close walls stay illuminated
+    torch.position.set(0, 0.5, -0.2);
     camera.add(torch);
 
     torchTarget = new THREE.Object3D();


### PR DESCRIPTION
## Summary
- offset torch slightly forward so walls stay illuminated when player is close
- mirror torch positioning logic for standalone module

## Testing
- `npm test` *(fails: ENOENT: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e2784f908333b65225c918379110