### PR TITLE
Keep torch horizontal to illuminate walls

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -282,6 +282,10 @@ function updateTorchTarget(camera, torch) {
     camera.getWorldPosition(worldPos);
     const worldDir = new THREE.Vector3();
     camera.getWorldDirection(worldDir);
+    // Ignore vertical component so the torch always aims horizontally,
+    // keeping walls illuminated even when the player looks down.
+    worldDir.y = 0;
+    worldDir.normalize();
     torch.target.position.copy(worldPos.clone().add(worldDir.multiplyScalar(10)));
     if (torch.target.parent !== scene) scene.add(torch.target);
 }

--- a/js/torch.js
+++ b/js/torch.js
@@ -95,6 +95,10 @@ export function updateTorchTarget(camera) {
     camera.getWorldPosition(worldPos);
     const worldDir = new THREE.Vector3();
     camera.getWorldDirection(worldDir);
+    // Keep the torch aimed horizontally so walls stay lit
+    // even if the player looks down toward the floor.
+    worldDir.y = 0;
+    worldDir.normalize();
     torchTarget.position.copy(worldPos.clone().add(worldDir.multiplyScalar(10)));
     if (torchTarget.parent !== sceneRef) sceneRef.add(torchTarget);
 }


### PR DESCRIPTION
## Summary
- Aim the flashlight horizontally to keep nearby walls lit even when the player looks down.
- Apply the same horizontal aiming fix to the reusable torch module.

## Testing
- `node --check js/main.js`
- `node --check js/torch.js`


------
https://chatgpt.com/codex/tasks/task_e_68c60385c9b0833384eac3b5f6ca00e6