### PR TITLE
Adjust torch position offset

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -131,7 +131,7 @@ const torch = new THREE.SpotLight(
     TORCH_DECAY
 );
 // Offset slightly forward so walls remain lit when the player is up close
-torch.position.set(0, 0.5, -0.2); // Above player's eyes
+torch.position.set(-0.5, 0.5, -0.2); // Above player's eyes
 camera.add(torch);
 torch.layers.enable(1);
 scene.add(torch.target);

--- a/js/torch.js
+++ b/js/torch.js
@@ -20,7 +20,7 @@ export function setupTorch(camera, scene) {
         TORCH_COLOR, TORCH_INTENSITY, TORCH_DISTANCE, TORCH_ANGLE, TORCH_PENUMBRA, TORCH_DECAY
     );
     // Place the light slightly in front of the camera so close walls stay illuminated
-    torch.position.set(0, 0.5, -0.2);
+    torch.position.set(-0.5, 0.5, -0.2);
     camera.add(torch);
 
     torchTarget = new THREE.Object3D();


### PR DESCRIPTION
## Summary
- Offset torch to the left by 0.5 units to reposition flashlight relative to player view.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c605692aa88333838ff17271137bbb