### PR TITLE
Limit zombie active radius

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -7,7 +7,8 @@ let zombieTypeIds = null;
 const DEFAULT_ZOMBIE_SIZE = [0.7, 1.8, 0.7];
 // Zombies beyond this distance from the player are neither rendered nor updated.
 // This reduces CPU/GPU workload when many zombies exist far from the action.
-const ZOMBIE_ACTIVE_DISTANCE = 30;
+// Maximum radius around the player where zombies remain active
+const ZOMBIE_ACTIVE_DISTANCE = 20;
 
 // Blood effect handling
 const bloodEffects = [];


### PR DESCRIPTION
## Summary
- Reduce ZOMBIE_ACTIVE_DISTANCE to cap how far zombies remain active
- Keep early distance check so distant zombies stay hidden and frozen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c619766ac88333b95ce34ed10d8a3f