### PR TITLE
Increase player view distance to 21

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -159,7 +159,7 @@ scene.fog = null;
 const geometries = {};
 const materials = {};
 const textureLoader = new THREE.TextureLoader();
-const PLAYER_VIEW_DISTANCE = 18;
+const PLAYER_VIEW_DISTANCE = 21;
 
 // Track models for zombies/objects
 const models = {};


### PR DESCRIPTION
## Summary
- raise `PLAYER_VIEW_DISTANCE` constant so walls remain loaded while zombies are active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c632547ccc8333b4141e073cfdc67e