### PR TITLE
Increase player view distance to avoid unloaded walls

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -159,7 +159,8 @@ scene.fog = null;
 const geometries = {};
 const materials = {};
 const textureLoader = new THREE.TextureLoader();
-const PLAYER_VIEW_DISTANCE = 21;
+// Increased to ensure zombies remain within loaded map bounds
+const PLAYER_VIEW_DISTANCE = 25;
 
 // Track models for zombies/objects
 const models = {};


### PR DESCRIPTION
## Summary
- Increase `PLAYER_VIEW_DISTANCE` to 25 so nearby zombies stay within loaded map tiles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6368cedb8833384dcd4121d931bb7