### PR TITLE
Add minimap overlay

### DIFF
--- a/js/hud.js
+++ b/js/hud.js
@@ -14,7 +14,7 @@ export function initHUD() {
     healthEl = document.createElement('div');
     healthEl.style.position = 'absolute';
     healthEl.style.top = '10px';
-    healthEl.style.right = '10px';
+    healthEl.style.left = '10px';
     healthEl.textContent = 'Health: 100';
     document.body.appendChild(healthEl);
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,8 +1,9 @@
 import { setupCamera, enablePointerLock } from './camera.js';
-import { loadMap, updateVisibleObjects } from './mapLoader.js';
+import { loadMap, updateVisibleObjects, getLoadedObjects } from './mapLoader.js';
 import { setupMovement } from './movement.js';
 import { checkPickups } from './pickup.js';
 import { initHUD, updateHUD } from './hud.js';
+import { initMinimap, updateMinimap } from './minimap.js';
 import { addPistolToCamera, shootPistol, updateBullets } from './pistol.js';
 import { initCrosshair, drawCrosshair, positionCrosshair } from './crosshair.js';
 import { setupZoom } from './zoom.js';
@@ -245,6 +246,7 @@ initCrosshair();
 enablePointerLock(renderer, cameraContainer, camera);
 setupZoom(camera, weaponCamera);
 addPistolToCamera(weaponCamera);
+initMinimap();
 
 document.addEventListener('mousedown', (e) => {
   if (e.button === 0) shootPistol(scene, camera);
@@ -314,6 +316,7 @@ function animate() {
 
   checkPickups(cameraContainer, scene);
   updateBullets(delta);
+  updateMinimap(cameraContainer, camera, getLoadedObjects());
 
   renderer.clear();
   renderer.render(scene, camera);

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -1,0 +1,51 @@
+let canvas, ctx;
+const SIZE = 150; // minimap size in pixels
+const SCALE = 4; // pixels per world unit
+
+export function initMinimap() {
+    canvas = document.createElement('canvas');
+    canvas.width = SIZE;
+    canvas.height = SIZE;
+    canvas.style.position = 'absolute';
+    canvas.style.top = '10px';
+    canvas.style.right = '10px';
+    canvas.style.border = '2px solid white';
+    canvas.style.background = 'rgba(0,0,0,0.4)';
+    canvas.style.zIndex = '100';
+    document.body.appendChild(canvas);
+    ctx = canvas.getContext('2d');
+}
+
+export function updateMinimap(player, camera, objects) {
+    if (!ctx) return;
+    ctx.clearRect(0, 0, SIZE, SIZE);
+
+    const half = SIZE / 2;
+    const range = half / SCALE; // world units that fit in minimap radius
+
+    // Draw objects relative to player position
+    ctx.fillStyle = 'white';
+    for (const obj of objects) {
+        const dx = obj.position.x - player.position.x;
+        const dz = obj.position.z - player.position.z;
+        if (Math.abs(dx) > range || Math.abs(dz) > range) continue;
+        const x = half + dx * SCALE;
+        const y = half + dz * SCALE;
+        ctx.fillRect(x - 2, y - 2, 4, 4);
+    }
+
+    // Draw player in center
+    ctx.fillStyle = 'red';
+    ctx.beginPath();
+    ctx.arc(half, half, 4, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Draw facing direction
+    const dir = new THREE.Vector3();
+    camera.getWorldDirection(dir);
+    ctx.strokeStyle = 'red';
+    ctx.beginPath();
+    ctx.moveTo(half, half);
+    ctx.lineTo(half + dir.x * 10, half + dir.z * 10);
+    ctx.stroke();
+}


### PR DESCRIPTION
## Summary
- Show a minimap in the top-right corner that draws nearby objects and player direction
- Move health text to top-left to make space for the minimap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6646bcc6c8333b6278f4becebca88