### PR TITLE
Add walls to minimap

### DIFF
--- a/js/minimap.js
+++ b/js/minimap.js
@@ -22,10 +22,26 @@ export function updateMinimap(player, camera, objects) {
 
     const half = SIZE / 2;
     const range = half / SCALE; // world units that fit in minimap radius
+    // Draw walls
+    ctx.fillStyle = '#888';
+    for (const obj of objects) {
+        if (obj.userData && obj.userData.type === 'wall') {
+            const dx = obj.position.x - player.position.x;
+            const dz = obj.position.z - player.position.z;
+            if (Math.abs(dx) > range || Math.abs(dz) > range) continue;
+            const x = half + dx * SCALE;
+            const y = half + dz * SCALE;
+            const geo = obj.userData.rules && obj.userData.rules.geometry;
+            const w = (geo ? geo[0] : 1) * SCALE;
+            const h = (geo ? geo[2] : 1) * SCALE;
+            ctx.fillRect(x - w / 2, y - h / 2, w, h);
+        }
+    }
 
-    // Draw objects relative to player position
+    // Draw other objects relative to player position
     ctx.fillStyle = 'white';
     for (const obj of objects) {
+        if (obj.userData && obj.userData.type === 'wall') continue;
         const dx = obj.position.x - player.position.x;
         const dz = obj.position.z - player.position.z;
         if (Math.abs(dx) > range || Math.abs(dz) > range) continue;


### PR DESCRIPTION
## Summary
- Render walls on the minimap as gray rectangles using wall geometry
- Keep other objects as white dots while drawing the player and facing direction as before

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6668f13708333889747fd90e2a347