### PR TITLE
feat: add full map preview

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,7 @@ import { loadMap, updateVisibleObjects, getLoadedObjects } from './mapLoader.js'
 import { setupMovement } from './movement.js';
 import { checkPickups } from './pickup.js';
 import { initHUD, updateHUD } from './hud.js';
-import { initMinimap, updateMinimap } from './minimap.js';
+import { initMinimap, updateMinimap, toggleFullMap } from './minimap.js';
 import { addPistolToCamera, shootPistol, updateBullets } from './pistol.js';
 import { initCrosshair, drawCrosshair, positionCrosshair } from './crosshair.js';
 import { setupZoom } from './zoom.js';
@@ -257,6 +257,9 @@ document.addEventListener('keydown', (e) => {
   if (e.code === 'KeyL') {
     godsSun.visible = !godsSun.visible;
     torch.visible = !godsSun.visible;
+  }
+  if (e.code === 'KeyM') {
+    toggleFullMap(cameraContainer, camera, getLoadedObjects());
   }
 });
 


### PR DESCRIPTION
## Summary
- toggle full map preview overlay with the M key
- draw entire level layout and player direction when preview is shown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c667cd09848333b0c2ec69c62c51a2