### PR TITLE
Display full map from saved_map.json

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,5 @@
 import { setupCamera, enablePointerLock } from './camera.js';
-import { loadMap, updateVisibleObjects, getLoadedObjects, getAllObjects } from './mapLoader.js';
+import { loadMap, updateVisibleObjects, getLoadedObjects } from './mapLoader.js';
 import { setupMovement } from './movement.js';
 import { checkPickups } from './pickup.js';
 import { initHUD, updateHUD } from './hud.js';
@@ -259,7 +259,7 @@ document.addEventListener('keydown', (e) => {
     torch.visible = !godsSun.visible;
   }
   if (e.code === 'KeyM') {
-    toggleFullMap(cameraContainer, camera, getAllObjects());
+    toggleFullMap(cameraContainer, camera);
   }
 });
 

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -1,6 +1,7 @@
 let canvas, ctx;
 let fullCanvas, fullCtx;
 let fullVisible = false;
+let fullMapData = null;
 const SIZE = 150; // minimap size in pixels
 const SCALE = 4; // pixels per world unit
 
@@ -67,12 +68,12 @@ export function updateMinimap(player, camera, objects) {
     ctx.lineTo(half + dir.x * 10, half + dir.z * 10);
     ctx.stroke();
 
-    if (fullVisible) {
-        drawFullMap(player, camera, objects);
+    if (fullVisible && fullMapData) {
+        drawFullMap(player, camera, fullMapData);
     }
 }
 
-export function toggleFullMap(player, camera, objects) {
+export async function toggleFullMap(player, camera) {
     if (!fullCanvas) {
         fullCanvas = document.createElement('canvas');
         fullCanvas.width = 600;
@@ -91,18 +92,28 @@ export function toggleFullMap(player, camera, objects) {
     fullVisible = !fullVisible;
     fullCanvas.style.display = fullVisible ? 'block' : 'none';
     if (fullVisible) {
-        drawFullMap(player, camera, objects);
+        if (!fullMapData) {
+            try {
+                const res = await fetch('saved_map.json');
+                fullMapData = await res.json();
+            } catch (e) {
+                console.error('Failed to load full map data', e);
+                fullMapData = [];
+            }
+        }
+        drawFullMap(player, camera, fullMapData);
     }
 }
 
-function drawFullMap(player, camera, objects) {
+function drawFullMap(player, camera, mapData) {
     if (!fullCtx) return;
     let minX = Infinity, maxX = -Infinity, minZ = Infinity, maxZ = -Infinity;
-    for (const obj of objects) {
-        minX = Math.min(minX, obj.position.x);
-        maxX = Math.max(maxX, obj.position.x);
-        minZ = Math.min(minZ, obj.position.z);
-        maxZ = Math.max(maxZ, obj.position.z);
+    for (const item of mapData) {
+        const [x, , z] = item.position;
+        minX = Math.min(minX, x);
+        maxX = Math.max(maxX, x);
+        minZ = Math.min(minZ, z);
+        maxZ = Math.max(maxZ, z);
     }
     const width = Math.max(maxX - minX, 1);
     const height = Math.max(maxZ - minZ, 1);
@@ -112,24 +123,13 @@ function drawFullMap(player, camera, objects) {
 
     fullCtx.clearRect(0, 0, fullCanvas.width, fullCanvas.height);
 
-    fullCtx.fillStyle = '#888';
-    for (const obj of objects) {
-        if (obj.userData && obj.userData.type === 'wall') {
-            const geo = obj.userData.rules && obj.userData.rules.geometry;
-            const w = (geo ? geo[0] : 1) * scale;
-            const h = (geo ? geo[2] : 1) * scale;
-            const x = (obj.position.x + offsetX) * scale;
-            const y = (obj.position.z + offsetZ) * scale;
-            fullCtx.fillRect(x - w / 2, y - h / 2, w, h);
-        }
-    }
-
-    fullCtx.fillStyle = 'white';
-    for (const obj of objects) {
-        if (obj.userData && obj.userData.type === 'wall') continue;
-        const x = (obj.position.x + offsetX) * scale;
-        const y = (obj.position.z + offsetZ) * scale;
-        fullCtx.fillRect(x - 2, y - 2, 4, 4);
+    for (const item of mapData) {
+        const [x, , z] = item.position;
+        const color = item.type === 'wall' ? '#888' : 'white';
+        fullCtx.fillStyle = color;
+        const sx = (x + offsetX) * scale;
+        const sy = (z + offsetZ) * scale;
+        fullCtx.fillRect(sx - 2, sy - 2, 4, 4);
     }
 
     const px = (player.position.x + offsetX) * scale;


### PR DESCRIPTION
## Summary
- Cache saved_map.json and render it when toggling the full map so the entire map is visible.
- Simplify full map toggling by loading map data on demand and redrawing from cached data.

## Testing
- `node --check js/minimap.js`
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c66e380ed483339b24656c337f6a34