### PR TITLE
feat: set fog-of-war radius to 8

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,5 @@
 import { setupCamera, enablePointerLock } from './camera.js';
-import { loadMap, updateVisibleObjects, getLoadedObjects } from './mapLoader.js';
+import { loadMap, updateVisibleObjects, getLoadedObjects, FOG_RADIUS } from './mapLoader.js';
 import { setupMovement } from './movement.js';
 import { checkPickups } from './pickup.js';
 import { initHUD, updateHUD } from './hud.js';
@@ -161,7 +161,8 @@ const geometries = {};
 const materials = {};
 const textureLoader = new THREE.TextureLoader();
 // Increased to ensure zombies remain within loaded map bounds
-const PLAYER_VIEW_DISTANCE = 25;
+// Use the fog-of-war radius from mapLoader so visibility is consistent.
+const PLAYER_VIEW_DISTANCE = FOG_RADIUS;
 
 // Track models for zombies/objects
 const models = {};

--- a/js/mapLoader.js
+++ b/js/mapLoader.js
@@ -10,6 +10,9 @@ let gltfModels = {};
 let gltfAnimations = {};
 let gltfLoadedFlags = {};
 const DEFAULT_ZOMBIE_SIZE = [0.7, 1.8, 0.7];
+// Radius, in world units, that the player can see. Objects outside this
+// distance remain hidden to create a fog-of-war effect.
+export const FOG_RADIUS = 8;
 
 const textureLoader = new THREE.TextureLoader();
 const gltfLoader = new THREE.GLTFLoader();
@@ -228,8 +231,8 @@ export async function loadMap(scene) {
         }
     }
 
-    updateVisibleObjects(scene, 0, 0, 40);
-    scene.fog = new THREE.Fog(0x000000, 2, 15);
+    updateVisibleObjects(scene, 0, 0, FOG_RADIUS);
+    scene.fog = new THREE.Fog(0x000000, 2, FOG_RADIUS);
     return loadedObjects;
 }
 


### PR DESCRIPTION
## Summary
- add constant fog-of-war radius of 8 units
- apply fog radius to initial scene setup and player view distance

## Testing
- `node --check js/mapLoader.js`
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c673c5074483339562a496c7f894ea