### PR TITLE
Add dynamic crosshair spread tied to movement and firing

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,16 +8,6 @@
     <style>
         body { margin: 0; overflow: hidden; }
         canvas { display: block; }
-        #crosshair {
-            position: absolute;
-            top: 50%; left: 50%;
-            width: 10px; height: 10px;
-            margin-top: -5px; margin-left: -5px;
-            background-color: rgba(255, 255, 255, 0.7);
-            border-radius: 50%;
-            pointer-events: none;
-        }
-
         .splash {
             position: absolute;
             width: 50px; height: 50px;
@@ -41,7 +31,6 @@
     </script>
 </head>
 <body>
-    <div id="crosshair"></div>
     <script type="module">
         import * as THREE from 'three';
         import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/js/crosshair.js
+++ b/js/crosshair.js
@@ -1,26 +1,89 @@
 let canvas, ctx;
 
+const CROSSHAIR_SIZE = 64;
+const HALF_SIZE = CROSSHAIR_SIZE / 2;
+const LINE_WIDTH = 2;
+const ARM_LENGTH = 10;
+const BASE_GAP = 6;
+const MOVING_GAP = 12;
+const SHOOT_RECOIL = 14;
+const RECOIL_DECAY = 30; // Units of gap per second removed after firing
+const SMOOTH_SPEED = 12; // Higher values snap faster to the desired gap
+
+let currentGap = BASE_GAP;
+let moving = false;
+let recoilGap = 0;
+
 export function initCrosshair() {
     canvas = document.createElement('canvas');
-    canvas.width = 30;
-    canvas.height = 30;
+    canvas.width = CROSSHAIR_SIZE;
+    canvas.height = CROSSHAIR_SIZE;
     canvas.style.position = 'absolute';
     canvas.style.pointerEvents = 'none';
+    canvas.style.zIndex = '1000';
     document.body.appendChild(canvas);
 
     ctx = canvas.getContext('2d');
     positionCrosshair();
 }
 
-export function drawCrosshair() {
-    ctx.clearRect(0, 0, 30, 30);
-    ctx.strokeStyle = 'red';
-    ctx.lineWidth = 2;
-    ctx.beginPath(); ctx.moveTo(15, 0); ctx.lineTo(15, 30); ctx.stroke();
-    ctx.beginPath(); ctx.moveTo(0, 15); ctx.lineTo(30, 15); ctx.stroke();
+export function drawCrosshair(delta = 0.016) {
+    if (!ctx) return;
+
+    recoilGap = Math.max(0, recoilGap - RECOIL_DECAY * delta);
+    const desiredGap = Math.max(
+        BASE_GAP,
+        moving ? MOVING_GAP : BASE_GAP,
+        BASE_GAP + recoilGap
+    );
+
+    const lerp = Math.min(delta * SMOOTH_SPEED, 1);
+    currentGap += (desiredGap - currentGap) * lerp;
+
+    ctx.clearRect(0, 0, CROSSHAIR_SIZE, CROSSHAIR_SIZE);
+    ctx.strokeStyle = '#ff0000';
+    ctx.lineWidth = LINE_WIDTH;
+    ctx.lineCap = 'round';
+
+    const center = HALF_SIZE;
+    const gap = currentGap;
+    const length = ARM_LENGTH;
+
+    // Up
+    ctx.beginPath();
+    ctx.moveTo(center, center - gap - length);
+    ctx.lineTo(center, center - gap);
+    ctx.stroke();
+
+    // Down
+    ctx.beginPath();
+    ctx.moveTo(center, center + gap);
+    ctx.lineTo(center, center + gap + length);
+    ctx.stroke();
+
+    // Left
+    ctx.beginPath();
+    ctx.moveTo(center - gap - length, center);
+    ctx.lineTo(center - gap, center);
+    ctx.stroke();
+
+    // Right
+    ctx.beginPath();
+    ctx.moveTo(center + gap, center);
+    ctx.lineTo(center + gap + length, center);
+    ctx.stroke();
 }
 
 export function positionCrosshair() {
-    canvas.style.left = `${(window.innerWidth - 30) / 2}px`;
-    canvas.style.top = `${(window.innerHeight - 30) / 2}px`;
+    if (!canvas) return;
+    canvas.style.left = `${(window.innerWidth - CROSSHAIR_SIZE) / 2}px`;
+    canvas.style.top = `${(window.innerHeight - CROSSHAIR_SIZE) / 2}px`;
+}
+
+export function setCrosshairMoving(isMoving) {
+    moving = isMoving;
+}
+
+export function notifyCrosshairShot() {
+    recoilGap = Math.max(recoilGap, SHOOT_RECOIL);
 }

--- a/js/main.js
+++ b/js/main.js
@@ -325,7 +325,7 @@ function animate() {
   renderer.render(scene, camera);
   renderer.clearDepth();
   renderer.render(scene, weaponCamera);
-  drawCrosshair();
+  drawCrosshair(delta);
 }
 
 window.onload = () => {

--- a/js/movement.js
+++ b/js/movement.js
@@ -1,5 +1,6 @@
 import { getLoadedObjects } from './mapLoader.js';
 import { reloadAmmo, setPistolMoving } from './pistol.js';
+import { setCrosshairMoving } from './crosshair.js';
 
 export function setupMovement(cameraContainer, camera) {
     const keys = {};
@@ -56,11 +57,16 @@ export function setupMovement(cameraContainer, camera) {
         }
 
         const isMoving = keys['KeyW'] || keys['KeyA'] || keys['KeyS'] || keys['KeyD'];
-        setPistolMoving(!!isMoving);
+        const movingBool = !!isMoving;
+        setPistolMoving(movingBool);
+        setCrosshairMoving(movingBool);
     }
 
     function setEnabled(val) {
         enabled = val;
+        if (!enabled) {
+            setCrosshairMoving(false);
+        }
     }
 
     return { update, setEnabled, checkCollision };

--- a/js/pistol.js
+++ b/js/pistol.js
@@ -1,6 +1,7 @@
 import { updateHUD } from './hud.js';
 import { getLoadedObjects } from './mapLoader.js';
 import { getZombies, damageZombie, registerGunshot } from './zombie.js';
+import { notifyCrosshairShot } from './crosshair.js';
 
 let pistol;
 let clipAmmo = 10;
@@ -247,6 +248,7 @@ export async function shootPistol(scene, camera) {
     }
 
     clipAmmo--;
+    notifyCrosshairShot();
     fireAction?.reset().play();
 
     const bullet = bulletTemplate.clone(true);


### PR DESCRIPTION
## Summary
- replace the static crosshair canvas with a red segmented crosshair whose gap widens smoothly while moving or after firing
- notify the crosshair module from the movement and pistol logic so the spread reflects player movement and gun recoil
- remove the legacy white crosshair element from the HTML so only the new red crosshair is shown

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c89ee8b5dc8333907f08fc694ec9bb