### PR TITLE
Add sneaking mechanics to shift key

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -314,7 +314,7 @@ function animate() {
   updateTorchTarget(camera, godsSun);
 
   // ---- Zombie animation & AI update ----
-  updateZombies(delta, cameraContainer, handlePlayerHit);
+  updateZombies(delta, cameraContainer, handlePlayerHit, movement.getState());
   updateBloodEffects(delta);
 
   checkPickups(cameraContainer, scene);

--- a/js/zombie.js
+++ b/js/zombie.js
@@ -348,7 +348,8 @@ function resolveZombieOverlap(zombie, collidables) {
 }
 
 // Update zombies: handle animation and simple wandering movement
-export function updateZombies(delta, playerObj, onPlayerHit) {
+export function updateZombies(delta, playerObj, onPlayerHit, playerState = {}) {
+    const { isSneaking = false } = playerState;
     const allObjects = getLoadedObjects();
     const collidableObjects = allObjects.filter(o => {
         const rules = (o.userData && o.userData.rules) ? o.userData.rules : {};
@@ -441,7 +442,10 @@ export function updateZombies(delta, playerObj, onPlayerHit) {
         }
 
         // Check for nearby gunshots and trigger temporary aggro
-        const spotRange = zombie.userData.spotDistance || 8;
+        const baseSpotRange = zombie.userData.spotDistance || 8;
+        // Sneaking halves the distance at which zombies can spot the player.
+        const spotRangeMultiplier = isSneaking ? 0.5 : 1;
+        const spotRange = baseSpotRange * spotRangeMultiplier;
         if (lastGunshot && zombie.position.distanceTo(lastGunshot.position) <= spotRange) {
             // Become aggressive toward the player for 3-10 seconds
             zombie.userData._aggroTime = 3 + Math.random() * 7;


### PR DESCRIPTION
## Summary
- slow the player when holding Shift by treating it as a sneaking state
- expose the player's movement state to zombie AI updates
- halve the zombie spotting distance when the player is sneaking

## Testing
- Not run (web app)


------
https://chatgpt.com/codex/tasks/task_e_68c8aa3911b08333935f089853e63303