### PR TITLE
Reduce lighter break interval to 5-25 seconds

### DIFF
--- a/js/torch.js
+++ b/js/torch.js
@@ -29,7 +29,7 @@ export function setupTorch(camera, scene) {
 
     torchWorking = true;
     torchBrokenUntil = 0;
-    nextBreakCheck = performance.now() + Math.random() * 35000 + 20000; // 20–55s window
+    nextBreakCheck = performance.now() + Math.random() * 20000 + 5000; // 5–25s window
 
     return torch;
 }
@@ -38,7 +38,7 @@ export function updateTorchFlicker(now) {
     if (torchWorking) {
         // Check if torch should break
         if (now > nextBreakCheck) {
-            if (Math.random() < 0.21) { // 21% chance every 20–55s
+            if (Math.random() < 0.21) { // 21% chance every 5–25s
                 torchWorking = false;
                 const duration = Math.random() * 500 + 3000; // 2–5s
                 torchBrokenUntil = now + duration;
@@ -47,7 +47,7 @@ export function updateTorchFlicker(now) {
                 playedOff = false;
                 playedDamnit = false;
             }
-            nextBreakCheck = now + (Math.random() * 35000 + 20000); // schedule next check in 20–55s
+            nextBreakCheck = now + (Math.random() * 20000 + 5000); // schedule next check in 5–25s
         }
         torch.intensity = TORCH_INTENSITY;
     } else {


### PR DESCRIPTION
## Summary
- shorten the torch's break-check schedule to 5–25 seconds to increase failure frequency
- update inline comments to document the new timing window

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8b01b97cc8333a0e9bd1bee0f6d27