### PR TITLE
Tie pistol bullet spread to crosshair gap

### DIFF
--- a/js/crosshair.js
+++ b/js/crosshair.js
@@ -7,6 +7,7 @@ const ARM_LENGTH = 10;
 const BASE_GAP = 12;
 const MOVING_GAP = 24;
 const SHOOT_RECOIL = 28;
+const MAX_SPREAD_DEGREES = 5;
 const RECOIL_DECAY = 30; // Units of gap per second removed after firing
 const SMOOTH_SPEED = 12; // Higher values snap faster to the desired gap
 
@@ -86,4 +87,18 @@ export function setCrosshairMoving(isMoving) {
 
 export function notifyCrosshairShot() {
     recoilGap = Math.max(recoilGap, SHOOT_RECOIL);
+}
+
+export function getCrosshairSpreadRadians() {
+    const effectiveGap = Math.max(
+        currentGap,
+        moving ? MOVING_GAP : BASE_GAP,
+        BASE_GAP + recoilGap
+    );
+
+    const extraGap = Math.max(0, effectiveGap - BASE_GAP);
+    const normalized = SHOOT_RECOIL > 0 ? Math.min(extraGap / SHOOT_RECOIL, 1) : 0;
+    const maxSpreadRadians = (MAX_SPREAD_DEGREES * Math.PI) / 180;
+
+    return normalized * maxSpreadRadians;
 }

--- a/js/pistol.js
+++ b/js/pistol.js
@@ -1,7 +1,7 @@
 import { updateHUD } from './hud.js';
 import { getLoadedObjects } from './mapLoader.js';
 import { getZombies, damageZombie, registerGunshot } from './zombie.js';
-import { notifyCrosshairShot } from './crosshair.js';
+import { notifyCrosshairShot, getCrosshairSpreadRadians } from './crosshair.js';
 
 let pistol;
 let clipAmmo = 10;
@@ -256,6 +256,20 @@ export async function shootPistol(scene, camera) {
     const direction = new THREE.Vector3();
     camera.getWorldDirection(direction);
     direction.normalize();
+
+    const spreadRadians = getCrosshairSpreadRadians();
+    if (spreadRadians > 0) {
+        const right = new THREE.Vector3(1, 0, 0).applyQuaternion(camera.quaternion).normalize();
+        const up = new THREE.Vector3(0, 1, 0).applyQuaternion(camera.quaternion).normalize();
+
+        const horizontalAngle = (Math.random() * 2 - 1) * spreadRadians;
+        const verticalAngle = (Math.random() * 2 - 1) * spreadRadians;
+
+        direction
+            .add(right.multiplyScalar(Math.tan(horizontalAngle)))
+            .add(up.multiplyScalar(Math.tan(verticalAngle)))
+            .normalize();
+    }
 
     const worldPosition = camera.getWorldPosition(new THREE.Vector3());
     bullet.position.copy(worldPosition);


### PR DESCRIPTION
## Summary
- expose a helper from the crosshair module that converts the current gap into a spread angle
- jitter fired bullet directions based on the current crosshair spread so recoil and movement affect accuracy

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8c71958648333beb58631fbfb1ba8