### PR TITLE
Align bullet spread with crosshair display

### DIFF
--- a/js/crosshair.js
+++ b/js/crosshair.js
@@ -90,13 +90,8 @@ export function notifyCrosshairShot() {
 }
 
 export function getCrosshairSpreadRadians() {
-    const effectiveGap = Math.max(
-        currentGap,
-        moving ? MOVING_GAP : BASE_GAP,
-        BASE_GAP + recoilGap
-    );
-
-    const extraGap = Math.max(0, effectiveGap - BASE_GAP);
+    const displayedGap = Math.max(currentGap, BASE_GAP);
+    const extraGap = Math.max(0, displayedGap - BASE_GAP);
     const normalized = SHOOT_RECOIL > 0 ? Math.min(extraGap / SHOOT_RECOIL, 1) : 0;
     const maxSpreadRadians = (MAX_SPREAD_DEGREES * Math.PI) / 180;
 


### PR DESCRIPTION
## Summary
- derive pistol bullet spread from the actually rendered crosshair gap
- keep spread normalization and clamping so accuracy still respects the configured maximum

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c8c94271108333bacbe1339144d1b3