### PR TITLE
Increase random zombie spawns to 400

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -145,7 +145,7 @@ const materials = {};
 const textureLoader = new THREE.TextureLoader();
 // Increased to ensure zombies remain within loaded map bounds
 const PLAYER_VIEW_DISTANCE = 25;
-const RANDOM_ZOMBIE_COUNT = 10;
+const RANDOM_ZOMBIE_COUNT = 400;
 
 // Track models for zombies/objects
 const models = {};


### PR DESCRIPTION
## Summary
- increase the RANDOM_ZOMBIE_COUNT constant so that automatic spawns add 400 zombies instead of 10

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8d57ae5708333a7dede4ab8f0e9ae