### PR TITLE
Prevent player interaction after death

### DIFF
--- a/js/crosshair.js
+++ b/js/crosshair.js
@@ -30,6 +30,9 @@ export function initCrosshair() {
 
 export function drawCrosshair(delta = 0.016) {
     if (!ctx) return;
+    if (canvas && canvas.style.display === 'none') {
+        return;
+    }
 
     recoilGap = Math.max(0, recoilGap - RECOIL_DECAY * delta);
     const desiredGap = Math.max(
@@ -96,4 +99,14 @@ export function getCrosshairSpreadRadians() {
     const maxSpreadRadians = (MAX_SPREAD_DEGREES * Math.PI) / 180;
 
     return normalized * maxSpreadRadians;
+}
+
+export function setCrosshairVisible(visible) {
+    if (!canvas) return;
+    canvas.style.display = visible ? 'block' : 'none';
+    if (!visible && ctx) {
+        ctx.clearRect(0, 0, CROSSHAIR_SIZE, CROSSHAIR_SIZE);
+        recoilGap = 0;
+        currentGap = BASE_GAP;
+    }
 }

--- a/js/hud.js
+++ b/js/hud.js
@@ -116,3 +116,13 @@ export function updateHUD(ammo, health) {
         renderHealthBar();
     }
 }
+
+export function setHUDVisible(visible) {
+    const display = visible ? 'block' : 'none';
+    if (hudContainer) {
+        hudContainer.style.display = display;
+    }
+    if (healthContainer) {
+        healthContainer.style.display = display;
+    }
+}

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -2,6 +2,7 @@ let canvas, ctx;
 let fullCanvas, fullCtx;
 let fullVisible = false;
 let fullMapData = null;
+let minimapEnabled = true;
 const SIZE = 150; // minimap size in pixels
 const SCALE = 4; // pixels per world unit
 // Track explored cells so the full map only reveals visited areas
@@ -22,7 +23,7 @@ export function initMinimap() {
 }
 
 export function updateMinimap(player, camera, objects) {
-    if (!ctx) return;
+    if (!ctx || !minimapEnabled) return;
     ctx.clearRect(0, 0, SIZE, SIZE);
 
     const half = SIZE / 2;
@@ -78,6 +79,10 @@ export function updateMinimap(player, camera, objects) {
 }
 
 export async function toggleFullMap(player, camera) {
+    if (!minimapEnabled) {
+        return;
+    }
+
     if (!fullCanvas) {
         fullCanvas = document.createElement('canvas');
         fullCanvas.width = 600;
@@ -106,6 +111,22 @@ export async function toggleFullMap(player, camera) {
             }
         }
         drawFullMap(player, camera, fullMapData);
+    }
+}
+
+export function setMinimapEnabled(enabled) {
+    minimapEnabled = enabled;
+
+    if (canvas) {
+        canvas.style.display = enabled ? 'block' : 'none';
+        if (!enabled && ctx) {
+            ctx.clearRect(0, 0, SIZE, SIZE);
+        }
+    }
+
+    if (!enabled && fullCanvas) {
+        fullCanvas.style.display = 'none';
+        fullVisible = false;
     }
 }
 


### PR DESCRIPTION
## Summary
- track a death state so player input, pistol shots and pointer lock are disabled once the player dies
- hide the HUD, minimap and crosshair when dead and ensure the minimap cannot be opened
- add pistol guards to cancel shooting/reloading work and hide the weapon when interaction is disabled

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c9013acb0c8333b2411de587c8b030