### PR TITLE
Scale zombie activity radius with frame timing and add tuning UI

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -7,7 +7,7 @@ import { initMinimap, updateMinimap, toggleFullMap, setMinimapEnabled } from './
 import { addPistolToCamera, shootPistol, updateBullets, setPistolEnabled } from './pistol.js';
 import { initCrosshair, drawCrosshair, positionCrosshair, setCrosshairVisible } from './crosshair.js';
 import { setupZoom } from './zoom.js';
-import { spawnZombiesFromMap, spawnRandomZombies, updateZombies, updateBloodEffects } from './zombie.js';
+import { spawnZombiesFromMap, spawnRandomZombies, updateZombies, updateBloodEffects, initZombieSettingsUI } from './zombie.js';
 import { setupTorch, updateTorchTarget, updateTorchFlicker } from './torch.js';
 
 // --- Scene and Camera setup ---
@@ -336,6 +336,7 @@ enablePointerLock(renderer, cameraContainer, camera);
 setupZoom(camera, weaponCamera);
 addPistolToCamera(weaponCamera);
 initMinimap();
+initZombieSettingsUI();
 
 document.addEventListener('mousedown', (e) => {
   if (isPlayerDead) return;


### PR DESCRIPTION
## Summary
- scale the zombie active radius based on frame time so fewer distant zombies update when FPS drops
- add a zombie activity slider with persistence so players can tune the base distance and see the effective value
- use the dynamic radius during zombie updates to control visibility and collisions

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c9072f0f0c833384f9657b59e7b345