### PR TITLE
Add spatial partition for static colliders

### DIFF
--- a/js/mapLoader.js
+++ b/js/mapLoader.js
@@ -10,6 +10,10 @@ let gltfModels = {};
 let gltfAnimations = {};
 let gltfLoadedFlags = {};
 let walkablePositions = [];
+
+const COLLISION_PARTITION_CELL_SIZE = 5;
+let staticCollisionPartition = new Map();
+let staticCollidableObjects = [];
 const DEFAULT_ZOMBIE_SIZE = [0.7, 1.8, 0.7];
 const WALKABLE_TYPE_KEYWORDS = ['floor', 'terrain', 'ground'];
 
@@ -69,6 +73,81 @@ function cacheBoundingBox(obj) {
     obj.userData._bboxScale = obj.scale.clone();
 }
 
+function clearCollisionPartition() {
+    staticCollidableObjects.forEach(obj => {
+        if (obj && obj.userData) {
+            delete obj.userData._inCollisionPartition;
+        }
+    });
+    staticCollisionPartition.clear();
+    staticCollidableObjects = [];
+}
+
+function collisionCellKey(ix, iz) {
+    return `${ix}|${iz}`;
+}
+
+function addObjectToPartition(obj) {
+    if (!obj) return;
+    if (!obj.userData) obj.userData = {};
+    if (!obj.userData._bbox) {
+        cacheBoundingBox(obj);
+    }
+    const box = obj.userData._bbox;
+    if (!box) return;
+    const min = box.min;
+    const max = box.max;
+    const startX = Math.floor(min.x / COLLISION_PARTITION_CELL_SIZE);
+    const endX = Math.floor(max.x / COLLISION_PARTITION_CELL_SIZE);
+    const startZ = Math.floor(min.z / COLLISION_PARTITION_CELL_SIZE);
+    const endZ = Math.floor(max.z / COLLISION_PARTITION_CELL_SIZE);
+    for (let ix = startX; ix <= endX; ix++) {
+        for (let iz = startZ; iz <= endZ; iz++) {
+            const key = collisionCellKey(ix, iz);
+            let cell = staticCollisionPartition.get(key);
+            if (!cell) {
+                cell = [];
+                staticCollisionPartition.set(key, cell);
+            }
+            cell.push(obj);
+        }
+    }
+    obj.userData._inCollisionPartition = true;
+    staticCollidableObjects.push(obj);
+}
+
+function buildCollisionPartition(objects) {
+    clearCollisionPartition();
+    objects.forEach(addObjectToPartition);
+}
+
+export function queryStaticColliders(box) {
+    if (!box) return [];
+    if (staticCollisionPartition.size === 0) {
+        return staticCollidableObjects.slice();
+    }
+    const min = box.min;
+    const max = box.max;
+    const startX = Math.floor(min.x / COLLISION_PARTITION_CELL_SIZE);
+    const endX = Math.floor(max.x / COLLISION_PARTITION_CELL_SIZE);
+    const startZ = Math.floor(min.z / COLLISION_PARTITION_CELL_SIZE);
+    const endZ = Math.floor(max.z / COLLISION_PARTITION_CELL_SIZE);
+    const result = new Set();
+    for (let ix = startX; ix <= endX; ix++) {
+        for (let iz = startZ; iz <= endZ; iz++) {
+            const key = collisionCellKey(ix, iz);
+            const cell = staticCollisionPartition.get(key);
+            if (!cell) continue;
+            cell.forEach(obj => result.add(obj));
+        }
+    }
+    return Array.from(result);
+}
+
+export function isStaticCollidable(obj) {
+    return Boolean(obj && obj.userData && obj.userData._inCollisionPartition);
+}
+
 export async function loadMap(scene) {
     // GitHub Pages and other static hosts cannot execute PHP files.
     // Instead of requesting "mapmaker.php" to list available JSON files,
@@ -82,6 +161,7 @@ export async function loadMap(scene) {
     gltfModels = {};
     gltfAnimations = {};
     gltfLoadedFlags = {};
+    clearCollisionPartition();
 
     let allDefinitions = [];
     let gltfPromises = [];
@@ -260,6 +340,12 @@ export async function loadMap(scene) {
             }
         }
     }
+
+    const staticObjects = loadedObjects.filter(obj => {
+        const rules = obj?.userData?.rules;
+        return rules && rules.collidable;
+    });
+    buildCollisionPartition(staticObjects);
 
     updateVisibleObjects(scene, 0, 0, 40);
     scene.fog = new THREE.Fog(0x000000, 2, 15);

--- a/js/zombie.js
+++ b/js/zombie.js
@@ -1,6 +1,6 @@
 // zombie.js
 
-import { getLoadedObjects, getAllObjects } from './mapLoader.js';
+import { getLoadedObjects, getAllObjects, queryStaticColliders, isStaticCollidable } from './mapLoader.js';
 
 let zombies = [];
 let zombieTypeIds = null;
@@ -736,10 +736,19 @@ function checkZombieCollision(zombie, proposed, collidables) {
         size[2] - ZOMBIE_COLLISION_MARGIN
     );
     const box = new THREE.Box3().setFromCenterAndSize(center, boxSize);
-    for (const obj of collidables) {
-        if (obj === zombie) continue;
+    const staticCandidates = queryStaticColliders(box);
+    for (const obj of staticCandidates) {
+        if (!obj || obj === zombie) continue;
         const objBox = getCachedBox(obj);
         if (box.intersectsBox(objBox)) return true;
+    }
+    if (Array.isArray(collidables)) {
+        for (const obj of collidables) {
+            if (!obj || obj === zombie) continue;
+            if (isStaticCollidable(obj)) continue;
+            const objBox = getCachedBox(obj);
+            if (box.intersectsBox(objBox)) return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
## Summary
- build a spatial hash for static collidable map objects during map loading and expose query helpers
- reuse the cached hash in zombie collision checks while keeping a fallback for dynamic colliders
- mark static objects so dynamic collision loops skip duplicates

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c915a0e468833391dfeff4603a42bd