### PR TITLE
Implement instanced LOD meshes for distant zombies

### DIFF
--- a/models/zombie_lod.json
+++ b/models/zombie_lod.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "defaultModel": "voxelZombie",
+  "models": {
+    "voxelZombie": {
+      "tintStrength": 0.35,
+      "maxInstances": 512,
+      "parts": [
+        { "shape": "box", "size": [0.18, 0.8, 0.2], "offset": [-0.12, 0.4, 0], "color": "#362b1f" },
+        { "shape": "box", "size": [0.18, 0.8, 0.2], "offset": [0.12, 0.4, 0], "color": "#362b1f" },
+        { "shape": "box", "size": [0.5, 0.9, 0.26], "offset": [0, 1.05, 0], "color": "#4c6940" },
+        { "shape": "box", "size": [0.44, 0.5, 0.24], "offset": [0, 1.45, 0], "color": "#5d7e4c" },
+        { "shape": "box", "size": [0.18, 0.7, 0.2], "offset": [-0.34, 1.05, 0], "color": "#2f261d" },
+        { "shape": "box", "size": [0.18, 0.7, 0.2], "offset": [0.34, 1.05, 0], "color": "#2f261d" },
+        { "shape": "box", "size": [0.32, 0.32, 0.24], "offset": [0, 1.74, 0], "color": "#8fb083" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable voxel-style zombie LOD description for instanced rendering
- wrap zombie construction in a root object and track detail nodes for LOD toggling
- switch zombies between detailed meshes and instanced LOD representations based on distance

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c91afbacd48333af1c885efd9b8cbd