### PR TITLE
Increase pistol damage

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -512,7 +512,7 @@ export function updateBullets(deltaTime) {
                 const zombieBox = new THREE.Box3().setFromObject(zombie);
                 if (bulletBox.intersectsBox(zombieBox)) {
                     hit = true;
-                    damageZombie(zombie, 1, bullet.userData.velocity, bullet.position.clone());
+                    damageZombie(zombie, 3, bullet.userData.velocity, bullet.position.clone());
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
- triple the pistol bullet damage applied to zombies to raise player damage output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c2dd708c8333903e8a7b26c98eb3