### PR TITLE
Increase pistol damage to 9

### DIFF
--- a/js/pistol.js
+++ b/js/pistol.js
@@ -512,7 +512,7 @@ export function updateBullets(deltaTime) {
                 const zombieBox = new THREE.Box3().setFromObject(zombie);
                 if (bulletBox.intersectsBox(zombieBox)) {
                     hit = true;
-                    damageZombie(zombie, 3, bullet.userData.velocity, bullet.position.clone());
+                    damageZombie(zombie, 9, bullet.userData.velocity, bullet.position.clone());
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
- increase pistol bullet damage to 9 so each hit deals triple damage to zombies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c53a7920833387731bf8764bf21d