### PR TITLE
Improve zombie hit detection reliability

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -131,7 +131,7 @@ function getSafeZoneList() {
     return Array.isArray(zones) ? zones : [];
 }
 
-function getZombieBoundingBox(zombie, position, includeMargin = true) {
+export function getZombieBoundingBox(zombie, position, includeMargin = true) {
     const geometry = getZombieGeometry(zombie);
     const width = (geometry?.[0] ?? DEFAULT_ZOMBIE_SIZE[0]) || DEFAULT_ZOMBIE_SIZE[0];
     const height = (geometry?.[1] ?? DEFAULT_ZOMBIE_SIZE[1]) || DEFAULT_ZOMBIE_SIZE[1];


### PR DESCRIPTION
## Summary
- cast rays along each bullet's travel to detect collisions so shots no longer skip past zombies
- reuse the zombie geometry-based bounding box helper (now exported) with a bit of padding for consistent hit detection

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9c9f003ec8333b2b459c56b1884f9