### PR TITLE
Add global loading overlay and asset progress tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,73 @@
             animation: fadeout 0.5s forwards;
         }
 
+        #loading-overlay {
+            position: fixed;
+            inset: 0;
+            background: radial-gradient(circle at top, rgba(40, 40, 40, 0.95), rgba(5, 5, 5, 0.98));
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #ffffff;
+            font-family: 'Arial', sans-serif;
+            z-index: 200;
+            transition: opacity 0.4s ease;
+        }
+
+        #loading-overlay.loading-overlay--hidden {
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        .loading-content {
+            width: min(420px, 80vw);
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            padding: 32px 24px;
+            border-radius: 12px;
+            background: rgba(0, 0, 0, 0.45);
+            box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
+        }
+
+        .loading-title {
+            font-size: 22px;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            font-weight: bold;
+            color: #ffb347;
+        }
+
+        .loading-bar {
+            height: 12px;
+            background: rgba(255, 255, 255, 0.15);
+            border-radius: 999px;
+            overflow: hidden;
+            position: relative;
+        }
+
+        .loading-bar-progress {
+            height: 100%;
+            width: 100%;
+            transform-origin: left center;
+            transform: scaleX(0);
+            background: linear-gradient(90deg, #ff512f, #dd2476);
+            transition: transform 0.2s ease;
+        }
+
+        .loading-percentage {
+            font-size: 18px;
+            font-weight: bold;
+            letter-spacing: 0.08em;
+        }
+
+        .loading-message {
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.8);
+            min-height: 20px;
+        }
+
         @keyframes fadeout {
             to { opacity: 0; transform: scale(2); }
         }
@@ -31,6 +98,16 @@
     </script>
 </head>
 <body>
+    <div id="loading-overlay">
+        <div class="loading-content">
+            <div class="loading-title">Loading Game</div>
+            <div class="loading-bar">
+                <div id="loading-bar-progress" class="loading-bar-progress"></div>
+            </div>
+            <div id="loading-percentage" class="loading-percentage">0%</div>
+            <div id="loading-message" class="loading-message">Initializing...</div>
+        </div>
+    </div>
     <script type="module">
         import * as THREE from 'three';
         import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';


### PR DESCRIPTION
## Summary
- add a full-screen loading overlay with progress messaging while assets load
- centralize loading progress tracking via THREE.LoadingManager and shared helpers
- hook map and zombie loaders into the manager so JSON, textures, and GLTF assets report progress

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9cf01f9e8833385d2ce9c14fc461a