### PR TITLE
Prevent shooting when acquiring pointer lock

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -33,6 +33,21 @@ renderer.autoClear = false;
 document.body.appendChild(renderer.domElement);
 const canvas = renderer.domElement;
 
+const canPointerLock = typeof canvas.requestPointerLock === 'function';
+let isPointerLocked = !canPointerLock;
+
+if (canPointerLock) {
+  const updatePointerLockState = () => {
+    isPointerLocked = document.pointerLockElement === canvas;
+  };
+
+  document.addEventListener('pointerlockchange', updatePointerLockState);
+  document.addEventListener('pointerlockerror', () => {
+    isPointerLocked = false;
+  });
+  updatePointerLockState();
+}
+
 const loadingOverlay = document.getElementById('loading-overlay');
 const loadingBarProgress = document.getElementById('loading-bar-progress');
 const loadingPercentage = document.getElementById('loading-percentage');
@@ -495,6 +510,7 @@ initZombieSettingsUI();
 
 document.addEventListener('mousedown', (e) => {
   if (isPlayerDead) return;
+  if (!isPointerLocked) return;
   if (e.button === 0) shootPistol(scene, camera);
 });
 


### PR DESCRIPTION
## Summary
- track pointer lock state on the game canvas so we know when pointer lock has been granted
- guard the pistol firing handler so the initial click that acquires pointer lock does not shoot
- default to allowing fire on platforms without pointer lock support

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c9d57f12b48333852e0ef6c4864bfb