### PR TITLE
Fix door model orientation and centering

### DIFF
--- a/js/mapLoader.js
+++ b/js/mapLoader.js
@@ -73,6 +73,47 @@ function applyPosition(mesh, position, rule) {
     }
 }
 
+function parseVector3(value) {
+    if (!value) return null;
+    if (Array.isArray(value)) {
+        const [x = 0, y = 0, z = 0] = value;
+        return [
+            Number(x) || 0,
+            Number(y) || 0,
+            Number(z) || 0
+        ];
+    }
+    if (typeof value === 'object') {
+        const { x = 0, y = 0, z = 0 } = value;
+        return [
+            Number(x) || 0,
+            Number(y) || 0,
+            Number(z) || 0
+        ];
+    }
+    return null;
+}
+
+function computeBoundingBox(object) {
+    const box = new THREE.Box3().setFromObject(object);
+    if (box.isEmpty()) {
+        box.makeEmpty();
+        object.traverse(node => {
+            if (node.isMesh && node.geometry) {
+                if (!node.geometry.boundingBox) {
+                    node.geometry.computeBoundingBox();
+                }
+                if (node.geometry.boundingBox) {
+                    const nodeBox = node.geometry.boundingBox.clone();
+                    nodeBox.applyMatrix4(node.matrixWorld);
+                    box.union(nodeBox);
+                }
+            }
+        });
+    }
+    return box;
+}
+
 // Cache a bounding box for the object so collision tests don't
 // need to reconstruct it every frame. The box is stored along with
 // the transform values so we can detect when it becomes stale.
@@ -130,6 +171,9 @@ export async function loadMap(scene) {
             geometry: obj.size ? obj.size.slice() : ((obj.ai === true || obj.isZombie === true) ? DEFAULT_ZOMBIE_SIZE.slice() : [1,1,1]),
             color: obj.color || '#999999',
             texture: obj.texture || null,
+            modelRotation: parseVector3(obj.modelRotation),
+            modelOffset: parseVector3(obj.modelOffset),
+            modelCenter: obj.modelCenter === true,
             safeZone: obj.safeZone !== undefined ? JSON.parse(JSON.stringify(obj.safeZone)) : false
         };
         if (!obj.model) {
@@ -210,38 +254,76 @@ export async function loadMap(scene) {
 
         // ---- NEW: Always allow zombies and model objects! ----
         if (rule && rule.model && gltfModels[type]) {
-            mesh = gltfModels[type].clone(true);
-            mesh.traverse(node => {
+            const modelRoot = gltfModels[type].clone(true);
+            modelRoot.traverse(node => {
                 if (node.isMesh) {
                     node.material = node.material.clone();
                     node.material.opacity = 1;
                     node.material.transparent = false;
                 }
             });
+
+            const container = new THREE.Group();
+            container.add(modelRoot);
+
+            if (rule.modelRotation) {
+                const [rx, ry, rz] = rule.modelRotation;
+                modelRoot.rotation.x += rx || 0;
+                modelRoot.rotation.y += ry || 0;
+                modelRoot.rotation.z += rz || 0;
+            }
+
+            modelRoot.updateMatrixWorld(true);
+
             if (rule.geometry) {
-                const box = new THREE.Box3().setFromObject(mesh);
+                const box = computeBoundingBox(modelRoot);
                 const size = new THREE.Vector3();
                 box.getSize(size);
                 if (size.x > 0 && size.y > 0 && size.z > 0) {
-                    mesh.scale.set(
+                    const scaleVec = new THREE.Vector3(
                         rule.geometry[0] / size.x,
                         rule.geometry[1] / size.y,
                         rule.geometry[2] / size.z
                     );
+                    modelRoot.scale.multiply(scaleVec);
                 }
             }
+
+            modelRoot.updateMatrixWorld(true);
+
+            if (rule.modelCenter) {
+                const centeredBox = computeBoundingBox(modelRoot);
+                const center = new THREE.Vector3();
+                centeredBox.getCenter(center);
+                if (Number.isFinite(center.x) && Number.isFinite(center.y) && Number.isFinite(center.z)) {
+                    modelRoot.position.sub(center);
+                }
+            }
+
+            if (rule.modelOffset) {
+                const [ox, oy, oz] = rule.modelOffset;
+                modelRoot.position.x += ox || 0;
+                modelRoot.position.y += oy || 0;
+                modelRoot.position.z += oz || 0;
+            }
+
+            modelRoot.updateMatrixWorld(true);
+
+            let mixer = null;
             if (gltfAnimations[type] && gltfAnimations[type].length > 0) {
-                const mixer = new THREE.AnimationMixer(mesh);
+                mixer = new THREE.AnimationMixer(modelRoot);
                 gltfAnimations[type].forEach(clip => {
                     const action = mixer.clipAction(clip);
                     action.play();
                 });
-                mesh.userData.mixer = mixer;
             }
+
+            mesh = container;
             applyPosition(mesh, position, rule);
             mesh.rotation.y = rotation;
             mesh.userData = { ...item, rules: rule };
             if (rule.ai) mesh.userData.ai = true;
+            if (mixer) mesh.userData.mixer = mixer;
             loadedObjects.push(mesh);
             if (rule.collidable) cacheBoundingBox(mesh);
         } else if (rule && (rule.ai || item.ai || item.isZombie)) {

--- a/objects.json
+++ b/objects.json
@@ -72,7 +72,13 @@
       0.05
     ],
     "collidable": false,
-    "model": "models/doors.glb"
+    "model": "models/doors.glb",
+    "modelRotation": [
+      1.5707963267948966,
+      0,
+      0
+    ],
+    "modelCenter": true
   },
   {
     "id": "water",


### PR DESCRIPTION
## Summary
- support custom rotation, offsets, and centering when instantiating GLTF-based map objects so static props can match box geometry placement
- wrap model instances in a container, scale them to the configured dimensions, and recenter door meshes to line up with existing map data
- rotate and center the door definition so all map doors use the upright model instead of the flat orientation

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9e431a0708333887e0b73dae78eac