### PR TITLE
Move zombie radius settings away from stats HUD

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -226,8 +226,8 @@ export function initZombieSettingsUI() {
 
     const container = document.createElement('div');
     container.style.position = 'fixed';
-    container.style.top = '12px';
-    container.style.left = '12px';
+    container.style.bottom = '16px';
+    container.style.left = '16px';
     container.style.padding = '10px 14px';
     container.style.background = 'rgba(0, 0, 0, 0.6)';
     container.style.color = '#ffffff';


### PR DESCRIPTION
## Summary
- reposition the zombie activity radius settings panel to the lower-left corner of the screen
- keep the player stats overlay unobstructed so kill counts remain visible when opened

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca1cd94abc8333acdb88d151548b3e