### PR TITLE
Add car teleportation between base and home maps

### DIFF
--- a/js/minimap.js
+++ b/js/minimap.js
@@ -2,6 +2,7 @@ let canvas, ctx;
 let fullCanvas, fullCtx;
 let fullVisible = false;
 let fullMapData = null;
+let mapSource = 'saved_map.json';
 let minimapEnabled = true;
 const SIZE = 150; // minimap size in pixels
 const SCALE = 4; // pixels per world unit
@@ -103,7 +104,7 @@ export async function toggleFullMap(player, camera) {
     if (fullVisible) {
         if (!fullMapData) {
             try {
-                const res = await fetch('saved_map.json');
+                const res = await fetch(mapSource);
                 fullMapData = await res.json();
             } catch (e) {
                 console.error('Failed to load full map data', e);
@@ -112,6 +113,19 @@ export async function toggleFullMap(player, camera) {
         }
         drawFullMap(player, camera, fullMapData);
     }
+}
+
+export function setMinimapMapSource(path) {
+    if (typeof path !== 'string') {
+        return;
+    }
+    const trimmed = path.trim();
+    if (!trimmed || mapSource === trimmed) {
+        return;
+    }
+    mapSource = trimmed;
+    fullMapData = null;
+    exploredCells.clear();
 }
 
 export function setMinimapEnabled(enabled) {

--- a/js/zombie.js
+++ b/js/zombie.js
@@ -42,6 +42,26 @@ export function registerLoadingManager(manager) {
     loadingManager = manager || THREE.DefaultLoadingManager;
 }
 
+export function clearZombies(scene) {
+    zombies.forEach(zombie => {
+        if (!zombie) return;
+        if (scene) {
+            if (zombie.parent === scene) {
+                scene.remove(zombie);
+            }
+        } else if (zombie.parent) {
+            zombie.parent.remove(zombie);
+        }
+    });
+    zombies = [];
+    zombieGrid.clear();
+    bloodEffects.forEach(effect => {
+        effect.mesh?.parent?.remove(effect.mesh);
+    });
+    bloodEffects.length = 0;
+    lastGunshot = null;
+}
+
 // Persistent spatial grid used to keep zombies separated.
 const zombieGrid = new Map();
 let zombieGridCellSize = Math.max(DEFAULT_ZOMBIE_SIZE[0], DEFAULT_ZOMBIE_SIZE[2]);

--- a/maps/home.json
+++ b/maps/home.json
@@ -1,0 +1,515 @@
+[
+  {
+    "position": [
+      -3,
+      0.5,
+      -3
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -3,
+      0.5,
+      3
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -3,
+      0.5,
+      4
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -2,
+      0.5,
+      -2
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -2,
+      0.5,
+      -1
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -2,
+      0.5,
+      0
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -2,
+      0.5,
+      1
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -2,
+      0.5,
+      3
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -2,
+      0.5,
+      4
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -1,
+      0.5,
+      -2
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -1,
+      0.5,
+      -1
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -1,
+      0.5,
+      0
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -1,
+      0.5,
+      1
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -1,
+      0.5,
+      2
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -1,
+      0.5,
+      3
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -1,
+      0.5,
+      4
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      0,
+      0.5,
+      -2
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      0,
+      0.5,
+      -1
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      0,
+      0.5,
+      0
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      0,
+      0.5,
+      1
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      0,
+      0.5,
+      2
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      0,
+      0.5,
+      3
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      0,
+      0.5,
+      4
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      1,
+      0.5,
+      -2
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      1,
+      0.5,
+      -1
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      1,
+      0.5,
+      0
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      1,
+      0.5,
+      1
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      1,
+      0.5,
+      2
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      1,
+      0.5,
+      3
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      1,
+      0.5,
+      4
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      2,
+      0.5,
+      -2
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      2,
+      0.5,
+      -1
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      2,
+      0.5,
+      0
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      2,
+      0.5,
+      1
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      2,
+      0.5,
+      3
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      2,
+      0.5,
+      4
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      3,
+      0.5,
+      -3
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      3,
+      0.5,
+      3
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      3,
+      0.5,
+      4
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -2,
+      0.5,
+      -3
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -1,
+      0.5,
+      -3
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      0,
+      0.5,
+      -3
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      1,
+      0.5,
+      -3
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      2,
+      0.5,
+      -3
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -3,
+      0.5,
+      -2
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      3,
+      0.5,
+      -2
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -3,
+      0.5,
+      -1
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      3,
+      0.5,
+      -1
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -3,
+      0.5,
+      0
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      3,
+      0.5,
+      0
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -3,
+      0.5,
+      1
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      3,
+      0.5,
+      1
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -3,
+      0.5,
+      2
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      3,
+      0.5,
+      2
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -2,
+      0.5,
+      2
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      2,
+      0.5,
+      2
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      0,
+      0.5,
+      0
+    ],
+    "rotation": 0,
+    "type": "3d car"
+  }
+]


### PR DESCRIPTION
## Summary
- introduce a new home map and allow interacting with a car to travel between maps
- update map loading, minimap, and save data to support switching between different map files
- clear existing zombies and reload map content during transitions to keep gameplay consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca30cd6df8833382defabd6ad6aaa0