### PR TITLE
Add es-module-shims polyfill for import map compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
             to { opacity: 0; transform: scale(2); }
         }
     </style>
+    <script async src="https://unpkg.com/es-module-shims/dist/es-module-shims.js"></script>
     <script type="importmap">
     {
       "imports": {


### PR DESCRIPTION
## Summary
- add the es-module-shims polyfill before the import map so browsers without native support can load the game

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca8f1c39148333aac608bc57dade17