### PR TITLE
Extend home map with additional floor and walls

### DIFF
--- a/maps/home.json
+++ b/maps/home.json
@@ -511,5 +511,185 @@
     ],
     "rotation": 0,
     "type": "3d car"
+  },
+  {
+    "position": [
+      -2,
+      0.5,
+      5
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -1,
+      0.5,
+      5
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      0,
+      0.5,
+      5
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      1,
+      0.5,
+      5
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      2,
+      0.5,
+      5
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      0,
+      0.5,
+      6
+    ],
+    "rotation": 0,
+    "type": "terrain"
+  },
+  {
+    "position": [
+      -3,
+      0.5,
+      3
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -3,
+      0.5,
+      4
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -3,
+      0.5,
+      5
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -3,
+      0.5,
+      6
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      3,
+      0.5,
+      3
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      3,
+      0.5,
+      4
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      3,
+      0.5,
+      5
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      3,
+      0.5,
+      6
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -2,
+      0.5,
+      5
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      2,
+      0.5,
+      5
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -2,
+      0.5,
+      6
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      -1,
+      0.5,
+      6
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      1,
+      0.5,
+      6
+    ],
+    "rotation": 0,
+    "type": "wall"
+  },
+  {
+    "position": [
+      2,
+      0.5,
+      6
+    ],
+    "rotation": 0,
+    "type": "wall"
   }
 ]


### PR DESCRIPTION
## Summary
- add extra terrain tiles near the front of the home map to widen the playable floor area
- extend the front and side perimeter walls to enclose the new space while leaving a doorway

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cddf50a61c8333a443f5270c50ecd6