### PR TITLE
Reduce dropped coin size

### DIFF
--- a/js/zombie.js
+++ b/js/zombie.js
@@ -240,6 +240,10 @@ if (THREE?.GLTFLoader) {
     const coinLoader = new THREE.GLTFLoader();
     coinLoader.load('models/coins.glb', gltf => {
         coinModel = gltf.scene;
+        if (coinModel) {
+            coinModel.scale.multiplyScalar(0.2);
+            coinModel.updateMatrixWorld(true);
+        }
     });
 }
 


### PR DESCRIPTION
## Summary
- shrink the loaded coin model so dropped coins appear five times smaller

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdeec2d9108333a9fdd416af8f4ff4