### PR TITLE
Ensure map objects animate

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -5,7 +5,8 @@ import {
   getLoadedObjects,
   getWalkablePositions,
   registerLoadingManager as registerMapLoadingManager,
-  removeObjectBySaveKey
+  removeObjectBySaveKey,
+  updateObjectAnimations
 } from './mapLoader.js';
 import { setupMovement } from './movement.js';
 import { checkPickups } from './pickup.js';
@@ -1118,6 +1119,7 @@ function animate() {
   // ---- Zombie animation & AI update ----
   updateZombies(delta, cameraContainer, handlePlayerHit, movement.getState());
   updateBloodEffects(delta);
+  updateObjectAnimations(delta);
 
   checkPickups(cameraContainer, scene);
   updateBullets(delta);

--- a/js/mapLoader.js
+++ b/js/mapLoader.js
@@ -734,6 +734,20 @@ export function getWalkablePositions() {
     return walkablePositions.map(pos => pos.clone());
 }
 
+export function updateObjectAnimations(deltaSeconds) {
+    if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0) {
+        return;
+    }
+
+    const targets = visibleObjects.length > 0 ? visibleObjects : loadedObjects;
+    for (let i = 0; i < targets.length; i++) {
+        const mixer = targets[i]?.userData?.mixer;
+        if (mixer && typeof mixer.update === 'function') {
+            mixer.update(deltaSeconds);
+        }
+    }
+}
+
 export function updateVisibleObjects(scene, playerX, playerZ, viewDist) {
     visibleObjects.forEach(obj => scene.remove(obj));
     visibleObjects = [];


### PR DESCRIPTION
## Summary
- update the map loader to expose an animation updater for GLTF-based objects
- drive the animation mixers from the main render loop so animated models like the car play correctly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdfc7a63e08333a3cabb52eb9e7a01