### PR TITLE
Enable animations for GLTF map objects

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -5,7 +5,8 @@ import {
   getLoadedObjects,
   getWalkablePositions,
   registerLoadingManager as registerMapLoadingManager,
-  removeObjectBySaveKey
+  removeObjectBySaveKey,
+  updateObjectMixers
 } from './mapLoader.js';
 import { setupMovement } from './movement.js';
 import { checkPickups } from './pickup.js';
@@ -1122,6 +1123,7 @@ function animate() {
   checkPickups(cameraContainer, scene);
   updateBullets(delta);
   updateDoors(delta);
+  updateObjectMixers(delta);
   updateMinimap(cameraContainer, camera, getLoadedObjects());
 
   renderer.clear();


### PR DESCRIPTION
## Summary
- track AnimationMixers for GLTF-based map objects when loading a map and clean them up on removal
- add an update helper in the map loader to advance active mixers each frame
- call the new update helper from the main render loop so GLTF object animations (like the car) play in-game

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdfe2c2cb88333940fc80317e4b270