### PR TITLE
Align door height with walls

### DIFF
--- a/js/editor-generators.js
+++ b/js/editor-generators.js
@@ -75,9 +75,11 @@ function connectRoomsWithMST(grid, rooms) {
 
     edges.forEach(edge => {
         if (union(edge.from, edge.to)) {
-            const roomA = rooms[edge.from], roomB = rooms[edge.to];
-            const ax = Math.floor(roomA.x + roomA.w / 2);
-            const ay = Math.floor(roomA.y + roomA.h / 2);
+            const roomA = rooms[edge.from], roomB = rooms[edge.to];            objects.push({ type: 'door', position: [doorX, 0.5, doorZ], rotation });
+        });
+    });
+
+
             const bx = Math.floor(roomB.x + roomB.w / 2);
             const by = Math.floor(roomB.y + roomB.h / 2);
 

--- a/js/mapLoader.js
+++ b/js/mapLoader.js
@@ -137,6 +137,16 @@ function applyPosition(mesh, position, rule) {
         }
     }
 
+    if (rule.id === 'door' && rule.geometry && rule.geometry.length >= 2) {
+        const halfHeight = rule.geometry[1] / 2;
+        if (Number.isFinite(halfHeight) && Number.isFinite(mesh.position.y)) {
+            const offset = mesh.position.y - halfHeight;
+            if (offset < -1e-6 && Math.abs(offset + 0.5) < 1e-4) {
+                mesh.position.y = halfHeight;
+            }
+        }
+    }
+
     const shouldAlignModelCenter = rule.model && rule.geometry && Number.isFinite(mesh.position.y);
     if (shouldAlignModelCenter) {
         const desiredCenterY = mesh.position.y;
@@ -374,6 +384,7 @@ export async function loadMap(scene, mapPath = 'maps/home.json') {
         );
 
         objectRules[obj.id] = {
+            id: obj.id,
             name: obj.name || obj.id,
             collidable: obj.collidable === true,
             model: obj.model || null,

--- a/objects.json
+++ b/objects.json
@@ -68,7 +68,7 @@
     "color": "#33231a",
     "size": [
       1,
-      2,
+      3,
       0.05
     ],
     "collidable": true,


### PR DESCRIPTION
## Summary
- raise the door geometry height so door models match the surrounding wall height
- adjust map loading to retain correct vertical placement for existing door entries and store rule ids
- update the dungeon generator to place doors at the tile midpoint for automatic centering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce90e6342c8333aa88c905b39fdc6a